### PR TITLE
[2022.11.14] Collage Page 레이아웃 제작

### DIFF
--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ScrapWindowContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: calc((100vw - 70px) / 2);
+  height: 100vh;
+  border-right: 3px solid #27292d;
+`;
+
+const ScrapWindow = () => {
+  return (
+    <ScrapWindowContainer>
+      <div></div>
+    </ScrapWindowContainer>
+  );
+};
+
+export default ScrapWindow;

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { useState } from "react";
+import styled from "styled-components";
+
+const SidebarContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 70px;
+  height: 100vh;
+  background-color: #27292d;
+  transition: all 0.3s ease-in-out;
+
+  .Sidebar-tools {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 1.5vh 0;
+    padding: 5px;
+    height: 35px;
+    width: 35px;
+    color: white;
+    border: 3px solid transparent;
+    border-radius: 10px;
+    user-select: none;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+  }
+
+  .Sidebar-tools:hover {
+    border: 3px solid white;
+  }
+
+  .Sidebar-tools > span {
+    font-size: 30px;
+  }
+
+  .Sidebar-folding {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 15vh;
+    padding: 5px;
+    height: 35px;
+    width: 35px;
+    color: #27292d;
+    background-color: white;
+    border-radius: 10px;
+    transform: rotate(180deg);
+    user-select: none;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+  }
+
+  .Sidebar-folding:hover {
+    background-color: hsl(0, 0%, 80%);
+  }
+
+  .Sidebar-folding > span {
+    font-size: 30px;
+  }
+`;
+
+const Sidebar = () => {
+  const [isFold, setIsFold] = useState(false);
+
+  return (
+    <SidebarContainer
+      style={{
+        transform: isFold ? ["translateX(-100px)"] : ["translateX(0px)"],
+      }}
+    >
+      <div className="Sidebar-tools">
+        <span className="material-symbols-outlined">arrow_selector_tool</span>
+      </div>
+      <div className="Sidebar-tools">
+        <span
+          className="material-symbols-outlined"
+          style={{ transform: ["translateY(-3px)"] }}
+        >
+          edit_square
+        </span>
+      </div>
+      <div className="Sidebar-tools">
+        <span className="material-symbols-outlined">border_color</span>
+      </div>
+      <div className="Sidebar-tools">
+        <span className="material-symbols-outlined">
+          check_box_outline_blank
+        </span>
+      </div>
+      <div className="Sidebar-tools">
+        <span className="material-symbols-outlined">link</span>
+      </div>
+      <div className="Sidebar-tools">
+        <span className="material-symbols-outlined">save</span>
+      </div>
+      <div className="Sidebar-tools">
+        <span className="material-symbols-outlined">layers</span>
+      </div>
+      <div
+        className="Sidebar-folding"
+        style={{
+          backgroundColor: isFold ? "#27292d" : "white",
+          color: isFold ? "white" : "#27292d",
+          transform: isFold ? "translateX(100px)" : "translateX(0px)",
+        }}
+        onClick={() => {
+          setIsFold(!isFold);
+        }}
+      >
+        <span
+          className="material-symbols-outlined"
+          style={{
+            transform: isFold ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+        >
+          logout
+        </span>
+      </div>
+    </SidebarContainer>
+  );
+};
+
+export default Sidebar;

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const WebWindowContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: calc((100vw - 70px) / 2);
+  height: 100vh;
+
+  iframe {
+    height: 100%;
+    width: 100%;
+    border: none;
+  }
+`;
+
+const WebWindow = () => {
+  return (
+    <WebWindowContainer>
+      <iframe
+        src="https://ko.reactjs.org/"
+        sandbox="allow-scripts allow-modals allow-top-navigation allow-same-origin allow-forms allow-popups"
+        allow="clipboard-read; clipboard-write"
+      />
+    </WebWindowContainer>
+  );
+};
+
+export default WebWindow;

--- a/src/pages/Main/index.jsx
+++ b/src/pages/Main/index.jsx
@@ -1,11 +1,25 @@
-import React from 'react';
-import { render } from 'react-dom';
-import './index.css';
+import React from "react";
+import { render } from "react-dom";
+import styled from "styled-components";
+import Sidebar from "../../containers/Sidebar";
+import ScrapWindow from "../../containers/ScrapWindow";
+import WebWindow from "../../containers/WebWindow";
+import "./index.css";
+
+const MainContainer = styled.div`
+  display: flex;
+`;
 
 const Main = () => {
-  return <div>Main Page</div>;
+  return (
+    <MainContainer>
+      <Sidebar />
+      <ScrapWindow />
+      <WebWindow />
+    </MainContainer>
+  );
 };
 
-render(<Main />, window.document.querySelector('#app-container'));
+render(<Main />, window.document.querySelector("#app-container"));
 
 if (module.hot) module.hot.accept();

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import styled from "styled-components";
 
 const PopupContainer = styled.div`
   position: absolute;
@@ -22,7 +22,7 @@ const PopupContainer = styled.div`
     width: 200px;
   }
 
-  .App-header {
+  .Popup-header {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -32,7 +32,7 @@ const PopupContainer = styled.div`
     color: white;
   }
 
-  .App-startScrap {
+  .Popup-collageButton {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -46,15 +46,15 @@ const PopupContainer = styled.div`
     transition: all 0.2s ease-in-out;
   }
 
-  .App-startScrap:hover {
+  .Popup-collageButton:hover {
     background-color: hsl(0, 0%, 90%);
   }
 
-  .App-startScrap:active {
+  .Popup-collageButton:active {
     background-color: hsl(0, 0%, 70%);
   }
 
-  .App-startScrap > span {
+  .Popup-collageButton > span {
     font-size: 50px;
   }
 `;
@@ -62,13 +62,13 @@ const PopupContainer = styled.div`
 const Popup = () => {
   return (
     <PopupContainer>
-      <header className="App-header">
+      <header className="Popup-header">
         <h1>Web Collage</h1>
       </header>
       <div
-        className="App-startScrap"
+        className="Popup-collageButton"
         onClick={() => {
-          window.open('main.html');
+          window.open("main.html");
         }}
       >
         <span className="material-symbols-outlined">file_copy</span>


### PR DESCRIPTION
# Topic
- Collage Page 레이아웃 제작

# Detail
![스크린샷 2022-11-14 오후 2 01 22](https://user-images.githubusercontent.com/99075014/201579077-bf451b46-1a44-4dbb-a07c-580b7d0b1865.png)

- Collage Page에 대한 전체적인 레이아웃 제작
- 사이드바 Hover 및 Click 이벤트 구현

# Kanban Link
https://expensive-scorpion-fab.notion.site/Layout-Collage-Page-bbc3f68bf4ea4d53988c7222516b24f1

# Kanban List
- [x]  위 디자인과 같은 레이아웃 제작
    - [x]  사이드바의 각 아이콘에 마우스를 올리면 Hover이벤트가 발생한다. 
    - [x]  사이드바 가장 아래쪽의 Fold버튼을 누르면 사이드바가 왼쪽으로 사라진 후
    Fold버튼이 있던 자리에 Open버튼이 생긴다.
    - [x]  Extention Popup에서 `Collage this page`버튼을 누르면
    본 페이지가 나오도록 구현.

# ETC
- 해당사항 없음