### PR TITLE
[2022.11.15] Web Window 선택요소 시각화용 테두리 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.5.1",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -24,9 +24,22 @@ const ScrapWindowContainer = styled.div`
 
   .ScrapWindow-fullscreen {
     position: absolute;
-    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    bottom: 10px;
+    left: 83px;
     user-select: none;
     cursor: pointer;
+
+    span {
+      font-size: 30px;
+      transition: all 0.4s ease-in-out;
+
+      :hover {
+        font-size: 35px;
+      }
+    }
   }
 `;
 

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -23,7 +23,9 @@ const WebWindowContainer = styled.div`
     top: 20px;
     background-color: ${COLORS.SUB_COLOR};
     border-radius: 5px;
+    box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
     transition: all 0.4s ease-in-out;
+    z-index: 2000000;
 
     input {
       padding: 5px 10px;
@@ -69,6 +71,7 @@ const WebWindowContainer = styled.div`
       width: 50px;
       color: ${COLORS.MAIN_COLOR};
       border-radius: 50px;
+      box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
       user-select: none;
       cursor: pointer;
       transition: all 0.4s ease-in-out;
@@ -95,6 +98,8 @@ const WebWindowContainer = styled.div`
     height: 40px;
     background-color: ${COLORS.SUB_COLOR};
     border-radius: 10px;
+    box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
+    z-index: 2000000;
 
     span {
       display: flex;
@@ -116,6 +121,10 @@ const WebWindowContainer = styled.div`
     width: 100%;
     border: none;
   }
+
+  .selectedDom {
+    border: 2px solid red;
+  }
 `;
 
 const BodyContainer = styled.div`
@@ -129,11 +138,17 @@ const WebWindow = () => {
   const [iframeDom, setIframeDom] = useState(null);
   const [isAddressBarFold, setIsAddressBarFold] = useState(true);
 
-  window.addEventListener("click", (event) => {
-    event.target.style.backgroundColor = "red";
-  });
-
   useEffect(() => {
+    const webWindow = document.getElementById("webWindowContent");
+
+    webWindow.addEventListener("mouseover", (event) => {
+      event.target.classList.add("selectedDom");
+    });
+
+    webWindow.addEventListener("mouseout", (event) => {
+      event.target.classList.remove("selectedDom");
+    });
+
     (async () => {
       const { data } = await axios.get("https://www.naver.com");
 
@@ -146,7 +161,7 @@ const WebWindow = () => {
       <div
         className="WebWindow-addressBarBox"
         style={{
-          transform: isAddressBarFold ? "translateY(-60px)" : "translateY(0px)",
+          transform: isAddressBarFold ? "translateY(-70px)" : "translateY(0px)",
         }}
       >
         <input
@@ -172,7 +187,7 @@ const WebWindow = () => {
           }}
           style={{
             transform: isAddressBarFold
-              ? "translateY(15px)"
+              ? "translateY(25px)"
               : "translateY(-15px)",
           }}
         >
@@ -185,7 +200,10 @@ const WebWindow = () => {
         <div>100%</div>
         <span>+</span>
       </div>
-      <BodyContainer dangerouslySetInnerHTML={{ __html: iframeDom }} />
+      <BodyContainer
+        id="webWindowContent"
+        dangerouslySetInnerHTML={{ __html: iframeDom }}
+      />
     </WebWindowContainer>
   );
 };

--- a/src/pages/Main/index.css
+++ b/src/pages/Main/index.css
@@ -3,6 +3,7 @@ body {
   max-width: 100vw;
   height: 100vh;
   margin: 0;
+  overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;


### PR DESCRIPTION
# Topic
- Web Window 선택요소 시각화용 테두리 구현

# Detail


https://user-images.githubusercontent.com/99075014/201861274-91221022-a288-49e5-bd82-30d0bfedb15f.mov



- 유저가 HTML Dom요소에 마우스를 Hover하면 
현재 어떤 Dom요소를 선택하고있는지 확인할 수 있는 테두리가 보이는 기능 구현.
- Web Window 주소창, 확대 축소창 안보이던 버그 수정

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Web-Window-6cf1e79d45e54b2eaba2c273bbd13c07

# Kanban List
- [x]  유저가 HTML Dom요소에 마우스를 Hover하면 
현재 어떤 Dom요소를 선택하고있는지 확인할 수 있는 테두리가 보인다.

# ETC
- 해당사항 없음