### PR TITLE
[2022.11.16] Web Window 드래그 앤 드랍 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.9.1",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.8.4",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.8.4",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.8.4",
+  "version": "0.9.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/constants/SIDEBAR_TOOLS.js
+++ b/src/constants/SIDEBAR_TOOLS.js
@@ -1,0 +1,30 @@
+export default [
+  {
+    ICON: "arrow_selector_tool",
+    MODE: "selectMode",
+  },
+  {
+    ICON: "edit_square",
+    MODE: "editMode",
+  },
+  {
+    ICON: "border_color",
+    MODE: "drawingMode",
+  },
+  {
+    ICON: "check_box_outline_blank",
+    MODE: "boxMode",
+  },
+  {
+    ICON: "link",
+    MODE: "shareMode",
+  },
+  {
+    ICON: "save",
+    MODE: "saveMode",
+  },
+  {
+    ICON: "layers",
+    MODE: "themeMode",
+  },
+];

--- a/src/containers/AddressBar/index.jsx
+++ b/src/containers/AddressBar/index.jsx
@@ -1,0 +1,136 @@
+import axios from "axios";
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import getCookie from "../../../utils/getCookie";
+import COLORS from "../../constants/COLORS";
+import { setUrlAddress } from "../../redux/reducers/urlAddress";
+
+const AddressBarBoxContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  padding: 5px 5px;
+  width: 250px;
+  top: 20px;
+  background-color: ${COLORS.SUB_COLOR};
+  border-radius: 5px;
+  box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
+  transition: all 0.4s ease-in-out;
+  z-index: 2000000;
+
+  input {
+    padding: 5px 10px;
+    width: 250px;
+    border-radius: 5px;
+
+    :focus {
+      outline: none;
+    }
+  }
+
+  .AddressBar-changeUrlButton {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: 5px;
+    height: 30px;
+    width: 40px;
+    color: ${COLORS.SUB_COLOR};
+    background-color: ${COLORS.MAIN_COLOR};
+    border-radius: 5px;
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+
+    :hover {
+      opacity: 0.9;
+    }
+
+    :active {
+      opacity: 0.7;
+    }
+  }
+
+  .AddressBar-foldButton {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    background-color: ${COLORS.SUB_COLOR};
+    height: 50px;
+    width: 50px;
+    color: ${COLORS.MAIN_COLOR};
+    border-radius: 50px;
+    box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
+    user-select: none;
+    cursor: pointer;
+    transition: all 0.4s ease-in-out;
+    z-index: -1;
+
+    :hover {
+      opacity: 0.9;
+    }
+
+    :active {
+      opacity: 0.7;
+    }
+  }
+`;
+
+const AddressBarBox = ({
+  isAddressBarFold,
+  setIsAddressBarFold,
+  setIframeDom,
+}) => {
+  const { urlAddress } = useSelector(({ urlAddress }) => urlAddress);
+
+  const dispatch = useDispatch();
+
+  return (
+    <AddressBarBoxContainer
+      style={{
+        transform: isAddressBarFold ? "translateY(-70px)" : "translateY(0px)",
+      }}
+    >
+      <input
+        defaultValue={
+          getCookie("urlAddress") ||
+          urlAddress ||
+          "https://eye-catch-danke-foresight.w3spaces.com"
+        }
+        onChange={(event) => {
+          dispatch(setUrlAddress(event.target.value));
+        }}
+      />
+      <span
+        className="material-symbols-outlined AddressBar-changeUrlButton"
+        onClick={async () => {
+          const { data } = await axios.get(urlAddress);
+
+          setIframeDom(data);
+        }}
+      >
+        arrow_forward
+      </span>
+      <div
+        className="AddressBar-foldButton"
+        onClick={() => {
+          setIsAddressBarFold(!isAddressBarFold);
+        }}
+        style={{
+          transform: isAddressBarFold
+            ? "translateY(25px)"
+            : "translateY(-15px)",
+        }}
+      >
+        <span className="material-symbols-outlined">arrow_drop_up</span>
+        <span className="material-symbols-outlined">arrow_drop_down</span>
+      </div>
+    </AddressBarBoxContainer>
+  );
+};
+
+export default AddressBarBox;

--- a/src/containers/Box/index.jsx
+++ b/src/containers/Box/index.jsx
@@ -8,10 +8,11 @@ const BoxContainer = styled.div`
   flex-direction: column;
   padding: 10px;
   width: 500px;
+  border: 2px solid #ccc;
 `;
 
-const Box = () => {
-  return <BoxContainer></BoxContainer>;
+const Box = ({ content }) => {
+  return <BoxContainer>{content}</BoxContainer>;
 };
 
 export default Box;

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -67,6 +67,7 @@ const ScrapWindow = () => {
     ({ selectModeOption }) => selectModeOption
   );
 
+  const [selectedBlock, setSelectedBlock] = useState(null);
   const [isFullScreen, setIsFullScreen] = useState(false);
 
   useEffect(() => {
@@ -80,16 +81,20 @@ const ScrapWindow = () => {
     const webWindow = document.getElementById("webWindow");
     const scrapWindow = document.getElementById("scrapWindowContentBox");
 
-    let width = parseInt(styles.width, 10);
-    let x = 0;
+    let isDrag = false;
+    let selectedElement;
+    let elementX = 0;
+    let elementY = 0;
+    let windowWidth = parseInt(styles.width, 10);
+    let windowX = 0;
 
     const onMouseMoveRightResize = (event) => {
-      const dx = event.clientX - x;
+      const dx = event.clientX - windowX;
 
-      x = event.clientX;
-      width = width + dx;
-      resizableElement.style.width = `${width}px`;
-      webWindow.style.width = `calc((100vw - 70px) - ${width}px)`;
+      windowX = event.clientX;
+      windowWidth = windowWidth + dx;
+      resizableElement.style.width = `${windowWidth}px`;
+      webWindow.style.width = `calc((100vw - 70px) - ${windowWidth}px)`;
     };
 
     const onMouseUpRightResize = () => {
@@ -97,7 +102,7 @@ const ScrapWindow = () => {
     };
 
     const onMouseDownRightResize = (event) => {
-      x = event.clientX;
+      windowX = event.clientX;
       resizableElement.style.left = styles.left;
       resizableElement.style.right = null;
 
@@ -106,20 +111,48 @@ const ScrapWindow = () => {
     };
 
     const scrapWindowContentMouseover = (event) => {
-      if (selectModeOptionRef.current !== "BoxAndBlockMode") return;
-
       event.target.classList.add("selectedDom");
     };
 
     const scrapWindowContentMouseout = (event) => {
-      if (selectModeOptionRef.current !== "BoxAndBlockMode") return;
-
       event.target.classList.remove("selectedDom");
+    };
+
+    const scrapWindowMousedown = (event) => {
+      if (selectModeOptionRef.current === "BoxAndBlockMode") return;
+
+      isDrag = true;
+      selectedElement = event.target;
+      selectedElement.style.position = "absolute";
+      positionY = event.target.offsetTop;
+      positionX = event.target.offsetLeft;
+      selectedElement.style.top = `${positionY}px`;
+      selectedElement.style.left = `${positionX}px`;
+    };
+
+    const scrapWindowMousemove = (event) => {
+      if (selectModeOptionRef.current === "BoxAndBlockMode") return;
+      if (!isDrag) return;
+
+      selectedElement.style.top = `${event.clientY}px`;
+      selectedElement.style.left = `${event.clientX}px`;
+    };
+
+    const scrapWindowMouseup = (event) => {
+      if (selectModeOptionRef.current === "BoxAndBlockMode") return;
+      if (!isDrag) return;
+
+      isDrag = false;
+      selectedElement.style.top = `${event.clientY}px`;
+      selectedElement.style.left = `${event.clientX}px`;
     };
 
     resizerRight.addEventListener("mousedown", onMouseDownRightResize);
     scrapWindow.addEventListener("mouseover", scrapWindowContentMouseover);
     scrapWindow.addEventListener("mouseout", scrapWindowContentMouseout);
+    scrapWindow.addEventListener("mousedown", scrapWindowMousedown);
+    scrapWindow.addEventListener("mousemove", scrapWindowMousemove);
+    scrapWindow.addEventListener("mouseup", scrapWindowMouseup);
   }, []);
 
   return (
@@ -143,11 +176,11 @@ const ScrapWindow = () => {
 
           if (isFullScreen) {
             webWindow.style.display = "flex";
-            ref.current.style.width = `calc((100vw - 70px) / 2)`;
+            resizableElementRef.current.style.width = `calc((100vw - 70px) / 2)`;
             webWindow.style.width = `calc((100vw - 70px) / 2)`;
           } else {
             webWindow.style.display = "none";
-            ref.current.style.width = `calc((100vw - 70px)`;
+            resizableElementRef.current.style.width = `calc((100vw - 70px)`;
             webWindow.style.width = `0px`;
           }
 

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -50,20 +50,35 @@ const ScrapWindowContainer = styled.div`
       }
     }
   }
+
+  .selectedDom {
+    border: 2px solid #ff6767;
+    border-radius: 2px;
+  }
 `;
 
 const ScrapWindow = () => {
-  const ref = useRef(null);
-  const refRight = useRef(null);
+  const resizableElementRef = useRef(null);
+  const rightResizerRef = useRef(null);
+  const selectModeOptionRef = useRef(null);
 
   const { blocks } = useSelector(({ blocks }) => blocks);
+  const { selectModeOption } = useSelector(
+    ({ selectModeOption }) => selectModeOption
+  );
 
   const [isFullScreen, setIsFullScreen] = useState(false);
 
   useEffect(() => {
-    const resizableElement = ref.current;
+    selectModeOptionRef.current = selectModeOption;
+  }, [selectModeOption]);
+
+  useEffect(() => {
+    const resizableElement = resizableElementRef.current;
+    const resizerRight = rightResizerRef.current;
     const styles = window.getComputedStyle(resizableElement);
     const webWindow = document.getElementById("webWindow");
+    const scrapWindow = document.getElementById("scrapWindowContentBox");
 
     let width = parseInt(styles.width, 10);
     let x = 0;
@@ -90,16 +105,25 @@ const ScrapWindow = () => {
       document.addEventListener("mouseup", onMouseUpRightResize);
     };
 
-    const resizerRight = refRight.current;
-    resizerRight.addEventListener("mousedown", onMouseDownRightResize);
+    const scrapWindowContentMouseover = (event) => {
+      if (selectModeOptionRef.current !== "BoxAndBlockMode") return;
 
-    return () => {
-      resizerRight.removeEventListener("mousedown", onMouseDownRightResize);
+      event.target.classList.add("selectedDom");
     };
+
+    const scrapWindowContentMouseout = (event) => {
+      if (selectModeOptionRef.current !== "BoxAndBlockMode") return;
+
+      event.target.classList.remove("selectedDom");
+    };
+
+    resizerRight.addEventListener("mousedown", onMouseDownRightResize);
+    scrapWindow.addEventListener("mouseover", scrapWindowContentMouseover);
+    scrapWindow.addEventListener("mouseout", scrapWindowContentMouseout);
   }, []);
 
   return (
-    <ScrapWindowContainer ref={ref} className="resizable">
+    <ScrapWindowContainer ref={resizableElementRef} className="resizable">
       <div id="scrapWindowContentBox" className="contentBox">
         <Box
           content={[
@@ -111,7 +135,7 @@ const ScrapWindow = () => {
           ]}
         />
       </div>
-      <div ref={refRight} className="resizer-r"></div>
+      <div ref={rightResizerRef} className="resizer-r"></div>
       <div
         className="ScrapWindow-fullscreen"
         onClick={() => {

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -6,13 +6,13 @@ import { useSelector } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
 import Block from "../Block";
-import Box from "../Box";
 
 const ScrapWindowContainer = styled.div`
   display: flex;
   width: calc((100vw - 70px) / 2);
   height: 100vh;
   border-radius: 3px;
+  user-select: none;
 
   .contentBox {
     display: flex;
@@ -57,6 +57,16 @@ const ScrapWindowContainer = styled.div`
   }
 `;
 
+const Box = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  flex-direction: column;
+  padding: 10px;
+  width: 500px;
+  border: 2px solid #ccc;
+`;
+
 const ScrapWindow = () => {
   const resizableElementRef = useRef(null);
   const rightResizerRef = useRef(null);
@@ -83,8 +93,6 @@ const ScrapWindow = () => {
 
     let isDrag = false;
     let selectedElement;
-    let elementX = 0;
-    let elementY = 0;
     let windowWidth = parseInt(styles.width, 10);
     let windowX = 0;
 
@@ -119,32 +127,54 @@ const ScrapWindow = () => {
     };
 
     const scrapWindowMousedown = (event) => {
-      if (selectModeOptionRef.current === "BoxAndBlockMode") return;
-
       isDrag = true;
       selectedElement = event.target;
+
       selectedElement.style.position = "absolute";
-      positionY = event.target.offsetTop;
-      positionX = event.target.offsetLeft;
-      selectedElement.style.top = `${positionY}px`;
-      selectedElement.style.left = `${positionX}px`;
+      selectedElement.style.top = `${event.target.offsetTop}px`;
+      selectedElement.style.left = `${event.target.offsetLeft}px`;
+      if (selectModeOptionRef.current === "BoxAndBlockMode") {
+      } else {
+      }
     };
 
     const scrapWindowMousemove = (event) => {
-      if (selectModeOptionRef.current === "BoxAndBlockMode") return;
       if (!isDrag) return;
 
       selectedElement.style.top = `${event.clientY}px`;
       selectedElement.style.left = `${event.clientX}px`;
+      if (selectModeOptionRef.current === "BoxAndBlockMode") {
+      } else {
+      }
     };
 
     const scrapWindowMouseup = (event) => {
-      if (selectModeOptionRef.current === "BoxAndBlockMode") return;
       if (!isDrag) return;
 
       isDrag = false;
-      selectedElement.style.top = `${event.clientY}px`;
-      selectedElement.style.left = `${event.clientX}px`;
+
+      const boxes = document.getElementsByClassName("BoxComponent");
+
+      if (selectModeOptionRef.current === "BoxAndBlockMode") {
+        for (let i = 0; i < boxes.length; i++) {
+          if (
+            boxes[i].getBoundingClientRect().top < event.clientY &&
+            boxes[i].getBoundingClientRect().bottom > event.clientY &&
+            boxes[i].getBoundingClientRect().left < event.clientX &&
+            boxes[i].getBoundingClientRect().right > event.clientX
+          ) {
+            selectedElement.style.position = "relative";
+            selectedElement.style.removeProperty("top");
+            selectedElement.style.removeProperty("left");
+            boxes[i].insertAdjacentElement("beforeend", selectedElement);
+
+            break;
+          }
+        }
+      } else {
+        selectedElement.style.top = `${event.clientY}px`;
+        selectedElement.style.left = `${event.clientX}px`;
+      }
     };
 
     resizerRight.addEventListener("mousedown", onMouseDownRightResize);
@@ -158,15 +188,12 @@ const ScrapWindow = () => {
   return (
     <ScrapWindowContainer ref={resizableElementRef} className="resizable">
       <div id="scrapWindowContentBox" className="contentBox">
-        <Box
-          content={[
-            <div>
-              {blocks.map((value, index) => {
-                return <Block html={value} key={index} />;
-              })}
-            </div>,
-          ]}
-        />
+        <Box className="BoxComponent"></Box>
+        <Box className="BoxComponent">
+          {blocks.map((value, index) => {
+            return <Block html={value} key={index} />;
+          })}
+        </Box>
       </div>
       <div ref={rightResizerRef} className="resizer-r"></div>
       <div

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -6,6 +6,7 @@ import { useSelector } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
 import Block from "../Block";
+import Box from "../Box";
 
 const ScrapWindowContainer = styled.div`
   display: flex;
@@ -100,9 +101,15 @@ const ScrapWindow = () => {
   return (
     <ScrapWindowContainer ref={ref} className="resizable">
       <div id="scrapWindowContentBox" className="contentBox">
-        {blocks.map((value, index) => {
-          return <Block html={value} key={index} />;
-        })}
+        <Box
+          content={[
+            <div>
+              {blocks.map((value, index) => {
+                return <Block html={value} key={index} />;
+              })}
+            </div>,
+          ]}
+        />
       </div>
       <div ref={refRight} className="resizer-r"></div>
       <div

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { useState } from "react";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
 import SIDEBAR_TOOLS from "../../constants/SIDEBAR_TOOLS";
+import { changeSelectModeOption } from "../../redux/reducers/selectModeOption";
+import SidebarFoldButton from "../SidebarFoldButton";
 import SidebarModal from "../SidebarModal";
 import SidebarTool from "../SidebarTool";
 
@@ -16,31 +19,9 @@ const SidebarContainer = styled.div`
   background-color: ${COLORS.MAIN_COLOR};
   transition: all 0.3s ease-in-out;
 
-  .Sidebar-folding {
-    position: absolute;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: 15vh;
-    padding: 5px;
-    bottom: 20px;
-    height: 45px;
-    width: 45px;
+  .Sidebar-selectedTool {
     color: ${COLORS.MAIN_COLOR};
     background-color: ${COLORS.SUB_COLOR};
-    border-radius: 10px;
-    transform: rotate(180deg);
-    user-select: none;
-    cursor: pointer;
-    transition: all 0.3s ease-in-out;
-  }
-
-  .Sidebar-folding:hover {
-    background-color: hsl(0, 0%, 80%);
-  }
-
-  .Sidebar-folding > span {
-    font-size: 30px;
   }
 
   .selectModeOption {
@@ -68,6 +49,8 @@ const SidebarContainer = styled.div`
 const Sidebar = () => {
   const [isFold, setIsFold] = useState(false);
 
+  const dispatch = useDispatch();
+
   return (
     <SidebarContainer
       style={{
@@ -78,36 +61,29 @@ const Sidebar = () => {
         content={[
           <div>
             <h3>Select Mode</h3>
-            <div className="selectModeOption">Box & Block</div>
-            <div className="selectModeOption">Free Position</div>
+            <div
+              className="selectModeOption"
+              onClick={() => {
+                dispatch(changeSelectModeOption("BoxAndBlockMode"));
+              }}
+            >
+              Box & Block
+            </div>
+            <div
+              className="selectModeOption"
+              onClick={() => {
+                dispatch(changeSelectModeOption("FreePositionMode"));
+              }}
+            >
+              Free Position
+            </div>
           </div>,
         ]}
       ></SidebarModal>
       {SIDEBAR_TOOLS.map((value, index) => {
-        return <SidebarTool icon={value.ICON} mode={value.MODE} />;
+        return <SidebarTool icon={value.ICON} mode={value.MODE} key={index} />;
       })}
-      <div
-        className="Sidebar-folding"
-        style={{
-          backgroundColor: isFold
-            ? `${COLORS.MAIN_COLOR}`
-            : `${COLORS.SUB_COLOR}`,
-          color: isFold ? `${COLORS.SUB_COLOR}` : `${COLORS.MAIN_COLOR}`,
-          transform: isFold ? "translateX(100px)" : "translateX(0px)",
-        }}
-        onClick={() => {
-          setIsFold(!isFold);
-        }}
-      >
-        <span
-          className="material-symbols-outlined"
-          style={{
-            transform: isFold ? "rotate(0deg)" : "rotate(180deg)",
-          }}
-        >
-          logout
-        </span>
-      </div>
+      <SidebarFoldButton isFold={isFold} setIsFold={setIsFold} />
     </SidebarContainer>
   );
 };

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -2,6 +2,9 @@ import React from "react";
 import { useState } from "react";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
+import SIDEBAR_TOOLS from "../../constants/SIDEBAR_TOOLS";
+import SidebarModal from "../SidebarModal";
+import SidebarTool from "../SidebarTool";
 
 const SidebarContainer = styled.div`
   display: flex;
@@ -13,38 +16,16 @@ const SidebarContainer = styled.div`
   background-color: ${COLORS.MAIN_COLOR};
   transition: all 0.3s ease-in-out;
 
-  .Sidebar-tools {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin: 1.5vh 0;
-    padding: 5px;
-    height: 35px;
-    width: 35px;
-    color: ${COLORS.SUB_COLOR};
-    border: 3px solid transparent;
-    border-radius: 10px;
-    user-select: none;
-    cursor: pointer;
-    transition: all 0.3s ease-in-out;
-  }
-
-  .Sidebar-tools:hover {
-    border: 3px solid white;
-  }
-
-  .Sidebar-tools > span {
-    font-size: 30px;
-  }
-
   .Sidebar-folding {
+    position: absolute;
     display: flex;
     justify-content: center;
     align-items: center;
     margin-top: 15vh;
     padding: 5px;
-    height: 35px;
-    width: 35px;
+    bottom: 20px;
+    height: 45px;
+    width: 45px;
     color: ${COLORS.MAIN_COLOR};
     background-color: ${COLORS.SUB_COLOR};
     border-radius: 10px;
@@ -61,6 +42,27 @@ const SidebarContainer = styled.div`
   .Sidebar-folding > span {
     font-size: 30px;
   }
+
+  .selectModeOption {
+    margin: 5px 0px;
+    padding: 3px 10px;
+    text-align: center;
+    background-color: ${COLORS.SUB_COLOR};
+    border: 1px solid ${COLORS.MAIN_COLOR};
+    border-radius: 5px;
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+
+    :hover {
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+    }
+
+    :active {
+      opacity: 0.4;
+    }
+  }
 `;
 
 const Sidebar = () => {
@@ -72,34 +74,18 @@ const Sidebar = () => {
         transform: isFold ? ["translateX(-100px)"] : ["translateX(0px)"],
       }}
     >
-      <div className="Sidebar-tools">
-        <span className="material-symbols-outlined">arrow_selector_tool</span>
-      </div>
-      <div className="Sidebar-tools">
-        <span
-          className="material-symbols-outlined"
-          style={{ transform: ["translateY(-3px)"] }}
-        >
-          edit_square
-        </span>
-      </div>
-      <div className="Sidebar-tools">
-        <span className="material-symbols-outlined">border_color</span>
-      </div>
-      <div className="Sidebar-tools">
-        <span className="material-symbols-outlined">
-          check_box_outline_blank
-        </span>
-      </div>
-      <div className="Sidebar-tools">
-        <span className="material-symbols-outlined">link</span>
-      </div>
-      <div className="Sidebar-tools">
-        <span className="material-symbols-outlined">save</span>
-      </div>
-      <div className="Sidebar-tools">
-        <span className="material-symbols-outlined">layers</span>
-      </div>
+      <SidebarModal
+        content={[
+          <div>
+            <h3>Select Mode</h3>
+            <div className="selectModeOption">Box & Block</div>
+            <div className="selectModeOption">Free Position</div>
+          </div>,
+        ]}
+      ></SidebarModal>
+      {SIDEBAR_TOOLS.map((value, index) => {
+        return <SidebarTool icon={value.ICON} mode={value.MODE} />;
+      })}
       <div
         className="Sidebar-folding"
         style={{

--- a/src/containers/SidebarFoldButton/index.jsx
+++ b/src/containers/SidebarFoldButton/index.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styled from "styled-components";
+import COLORS from "../../constants/COLORS";
+
+const SidebarFoldButtonContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 15vh;
+  padding: 5px;
+  bottom: 20px;
+  height: 45px;
+  width: 45px;
+  color: ${COLORS.MAIN_COLOR};
+  background-color: ${COLORS.SUB_COLOR};
+  border-radius: 10px;
+  transform: rotate(180deg);
+  user-select: none;
+  cursor: pointer;
+  transition: all 0.3s ease-in-out;
+
+  :hover {
+    background-color: hsl(0, 0%, 80%);
+  }
+
+  span {
+    font-size: 30px;
+  }
+`;
+
+const SidebarFoldButton = ({ isFold, setIsFold }) => {
+  return (
+    <SidebarFoldButtonContainer
+      style={{
+        backgroundColor: isFold
+          ? `${COLORS.MAIN_COLOR}`
+          : `${COLORS.SUB_COLOR}`,
+        color: isFold ? `${COLORS.SUB_COLOR}` : `${COLORS.MAIN_COLOR}`,
+        transform: isFold ? "translateX(100px)" : "translateX(0px)",
+      }}
+      onClick={() => {
+        setIsFold(!isFold);
+      }}
+    >
+      <span
+        className="material-symbols-outlined"
+        style={{
+          transform: isFold ? "rotate(0deg)" : "rotate(180deg)",
+        }}
+      >
+        logout
+      </span>
+    </SidebarFoldButtonContainer>
+  );
+};
+
+export default SidebarFoldButton;

--- a/src/containers/SidebarModal/index.jsx
+++ b/src/containers/SidebarModal/index.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import styled from "styled-components";
+import COLORS from "../../constants/COLORS";
+
+const SidebarModalContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 20px 30px;
+  top: 17vh;
+  left: 90px;
+  min-width: 250px;
+  background-color: ${COLORS.SUB_COLOR};
+  border: 2px solid ${COLORS.MAIN_COLOR};
+  border-radius: 5px;
+`;
+
+const SidebarModal = ({ content }) => {
+  return <SidebarModalContainer>{content}</SidebarModalContainer>;
+};
+
+export default SidebarModal;

--- a/src/containers/SidebarModal/index.jsx
+++ b/src/containers/SidebarModal/index.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
 
@@ -18,7 +19,17 @@ const SidebarModalContainer = styled.div`
 `;
 
 const SidebarModal = ({ content }) => {
-  return <SidebarModalContainer>{content}</SidebarModalContainer>;
+  const { selectedSidebarTool } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  return (
+    <SidebarModalContainer
+      style={{ display: selectedSidebarTool !== "selectMode" && "none" }}
+    >
+      {content}
+    </SidebarModalContainer>
+  );
 };
 
 export default SidebarModal;

--- a/src/containers/SidebarTool/index.jsx
+++ b/src/containers/SidebarTool/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import COLORS from "../../constants/COLORS";
+import { selectSidebarTool } from "../../redux/reducers/selectedSidebarTool";
 
 const SidebarToolContainer = styled.div`
   display: flex;
@@ -25,11 +26,6 @@ const SidebarToolContainer = styled.div`
   span {
     font-size: 30px;
   }
-
-  .Sidebar-selectedTool {
-    color: ${COLORS.MAIN_COLOR};
-    background-color: ${COLORS.SUB_COLOR};
-  }
 `;
 
 const SidebarTool = ({ icon, mode }) => {
@@ -41,7 +37,7 @@ const SidebarTool = ({ icon, mode }) => {
 
   return (
     <SidebarToolContainer
-      className={`${selectedSidebarTool === mode && "Sidebar-selectedTool"}`}
+      className={selectedSidebarTool === mode && "Sidebar-selectedTool"}
       onClick={() => {
         dispatch(selectSidebarTool(mode));
       }}

--- a/src/containers/SidebarTool/index.jsx
+++ b/src/containers/SidebarTool/index.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import COLORS from "../../constants/COLORS";
+
+const SidebarToolContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 1.5vh 0;
+  padding: 5px;
+  height: 45px;
+  width: 45px;
+  color: ${COLORS.SUB_COLOR};
+  border: 3px solid transparent;
+  border-radius: 10px;
+  user-select: none;
+  cursor: pointer;
+  transition: all 0.3s ease-in-out;
+
+  :hover {
+    border: 3px solid white;
+  }
+
+  span {
+    font-size: 30px;
+  }
+
+  .Sidebar-selectedTool {
+    color: ${COLORS.MAIN_COLOR};
+    background-color: ${COLORS.SUB_COLOR};
+  }
+`;
+
+const SidebarTool = ({ icon, mode }) => {
+  const { selectedSidebarTool } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  const dispatch = useDispatch();
+
+  return (
+    <SidebarToolContainer
+      className={`${selectedSidebarTool === mode && "Sidebar-selectedTool"}`}
+      onClick={() => {
+        dispatch(selectSidebarTool(mode));
+      }}
+    >
+      <span className="material-symbols-outlined">{icon}</span>
+    </SidebarToolContainer>
+  );
+};
+
+export default SidebarTool;

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -8,7 +8,6 @@ import getCookie from "../../../utils/getCookie";
 import COLORS from "../../constants/COLORS";
 import { addBlocks } from "../../redux/reducers/blocks";
 import { setUrlAddress } from "../../redux/reducers/urlAddress";
-import Block from "../Block";
 
 const WebWindowContainer = styled.div`
   display: flex;
@@ -18,6 +17,7 @@ const WebWindowContainer = styled.div`
   height: 100vh;
   width: calc((100vw - 70px) / 2);
   overflow-y: scroll;
+  user-select: none;
 
   .WebWindow-addressBarBox {
     display: flex;
@@ -98,7 +98,7 @@ const WebWindowContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    right: 10px;
+    right: 15px;
     bottom: 10px;
     width: 130px;
     height: 40px;
@@ -122,10 +122,30 @@ const WebWindowContainer = styled.div`
     }
   }
 
-  iframe {
-    height: 100%;
-    width: 100%;
-    border: none;
+  .WebWindow-scrapModeButton {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    bottom: 55px;
+    right: 15px;
+    height: 35px;
+    width: 35px;
+    background-color: ${COLORS.SUB_COLOR};
+    border-radius: 5px;
+    box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+    z-index: 2000000;
+
+    :hover {
+      opacity: 0.9;
+    }
+
+    :active {
+      opacity: 0.7;
+    }
   }
 
   .selectedDom {
@@ -143,6 +163,7 @@ const BodyContainer = styled.div`
 const WebWindow = () => {
   const blockRef = useRef(null);
   const webWindowRef = useRef(null);
+  const isScrapModeRef = useRef(true);
 
   const { urlAddress } = useSelector(({ urlAddress }) => urlAddress);
 
@@ -161,15 +182,25 @@ const WebWindow = () => {
     let positionX = 0;
     let positionY = 0;
 
-    webWindow.addEventListener("mouseover", (event) => {
-      event.target.classList.add("selectedDom");
-    });
+    document
+      .getElementById("webWindowContent")
+      .addEventListener("mouseover", (event) => {
+        if (!isScrapModeRef.current) return;
 
-    webWindow.addEventListener("mouseout", (event) => {
-      event.target.classList.remove("selectedDom");
-    });
+        event.target.classList.add("selectedDom");
+      });
+
+    document
+      .getElementById("webWindowContent")
+      .addEventListener("mouseout", (event) => {
+        if (!isScrapModeRef.current) return;
+
+        event.target.classList.remove("selectedDom");
+      });
 
     webWindow.addEventListener("mousedown", (event) => {
+      if (!isScrapModeRef.current) return;
+
       isDrag = true;
       block.style.display = "flex";
       selectedElement = event.target;
@@ -183,6 +214,7 @@ const WebWindow = () => {
     });
 
     window.addEventListener("mousemove", (event) => {
+      if (!isScrapModeRef.current) return;
       if (!isDrag) return;
 
       block.style.top = `${event.clientY}px`;
@@ -190,6 +222,7 @@ const WebWindow = () => {
     });
 
     window.addEventListener("mouseup", (event) => {
+      if (!isScrapModeRef.current) return;
       if (!isDrag) return;
 
       isDrag = false;
@@ -204,7 +237,10 @@ const WebWindow = () => {
     });
 
     (async () => {
-      const url = getCookie("urlAddress") || urlAddress;
+      const url =
+        getCookie("urlAddress") ||
+        urlAddress ||
+        "https://illuminating-extol-innovation.w3spaces.com/";
 
       const { data } = await axios.get(url);
 
@@ -266,6 +302,14 @@ const WebWindow = () => {
           <span className="material-symbols-outlined">arrow_drop_up</span>
           <span className="material-symbols-outlined">arrow_drop_down</span>
         </div>
+      </div>
+      <div
+        className="WebWindow-scrapModeButton"
+        onClick={() => {
+          isScrapModeRef.current = !isScrapModeRef.current;
+        }}
+      >
+        <span className="material-symbols-outlined">file_copy</span>
       </div>
       <div className="WebWindow-ratioButton">
         <span>-</span>

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -8,6 +8,7 @@ import getCookie from "../../../utils/getCookie";
 import COLORS from "../../constants/COLORS";
 import { addBlocks } from "../../redux/reducers/blocks";
 import { setUrlAddress } from "../../redux/reducers/urlAddress";
+import AddressBarBox from "../AddressBar";
 
 const WebWindowContainer = styled.div`
   display: flex;
@@ -18,80 +19,6 @@ const WebWindowContainer = styled.div`
   width: calc((100vw - 70px) / 2);
   overflow-y: scroll;
   user-select: none;
-
-  .WebWindow-addressBarBox {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: absolute;
-    padding: 5px 5px;
-    width: 250px;
-    top: 20px;
-    background-color: ${COLORS.SUB_COLOR};
-    border-radius: 5px;
-    box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
-    transition: all 0.4s ease-in-out;
-    z-index: 2000000;
-
-    input {
-      padding: 5px 10px;
-      width: 250px;
-      border-radius: 5px;
-
-      :focus {
-        outline: none;
-      }
-    }
-
-    .WebWindow-changeUrlButton {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-left: 5px;
-      height: 30px;
-      width: 40px;
-      color: ${COLORS.SUB_COLOR};
-      background-color: ${COLORS.MAIN_COLOR};
-      border-radius: 5px;
-      transition: all 0.2s ease-in-out;
-      user-select: none;
-      cursor: pointer;
-
-      :hover {
-        opacity: 0.9;
-      }
-
-      :active {
-        opacity: 0.7;
-      }
-    }
-
-    .WebWindow-foldButton {
-      position: absolute;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      flex-direction: column;
-      background-color: ${COLORS.SUB_COLOR};
-      height: 50px;
-      width: 50px;
-      color: ${COLORS.MAIN_COLOR};
-      border-radius: 50px;
-      box-shadow: 1px 2px 3px 0px rgba(0, 0, 0, 0.2);
-      user-select: none;
-      cursor: pointer;
-      transition: all 0.4s ease-in-out;
-      z-index: -1;
-
-      :hover {
-        opacity: 0.9;
-      }
-
-      :active {
-        opacity: 0.7;
-      }
-    }
-  }
 
   .WebWindow-ratioButton {
     position: absolute;
@@ -140,12 +67,21 @@ const WebWindowContainer = styled.div`
     z-index: 2000000;
 
     :hover {
-      opacity: 0.9;
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+      opacity: 0.7;
     }
 
     :active {
-      opacity: 0.7;
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+      opacity: 0.5;
     }
+  }
+
+  .WebWindow-scrapMode {
+    color: ${COLORS.SUB_COLOR};
+    background-color: ${COLORS.MAIN_COLOR};
   }
 
   .selectedDom {
@@ -163,42 +99,44 @@ const BodyContainer = styled.div`
 const WebWindow = () => {
   const blockRef = useRef(null);
   const webWindowRef = useRef(null);
-  const isScrapModeRef = useRef(true);
+  const isScrapModeRef = useRef(false);
 
   const { urlAddress } = useSelector(({ urlAddress }) => urlAddress);
 
   const [iframeDom, setIframeDom] = useState(null);
   const [selectedBlock, setSelectedBlock] = useState(null);
   const [isAddressBarFold, setIsAddressBarFold] = useState(true);
+  const [isScrapMode, setIsScrapMode] = useState(false);
 
   const dispatch = useDispatch();
 
   useEffect(() => {
+    isScrapModeRef.current = isScrapMode;
+  }, [isScrapMode]);
+
+  useEffect(() => {
     const webWindow = webWindowRef.current;
     const block = blockRef.current;
+    const webWindowContent = document.getElementById("webWindowContent");
 
     let isDrag = false;
     let selectedElement;
     let positionX = 0;
     let positionY = 0;
 
-    document
-      .getElementById("webWindowContent")
-      .addEventListener("mouseover", (event) => {
-        if (!isScrapModeRef.current) return;
+    const webWindowContentMouseover = (event) => {
+      if (!isScrapModeRef.current) return;
 
-        event.target.classList.add("selectedDom");
-      });
+      event.target.classList.add("selectedDom");
+    };
 
-    document
-      .getElementById("webWindowContent")
-      .addEventListener("mouseout", (event) => {
-        if (!isScrapModeRef.current) return;
+    const webWindowContentMouseout = (event) => {
+      if (!isScrapModeRef.current) return;
 
-        event.target.classList.remove("selectedDom");
-      });
+      event.target.classList.remove("selectedDom");
+    };
 
-    webWindow.addEventListener("mousedown", (event) => {
+    const webWindowMousedown = (event) => {
       if (!isScrapModeRef.current) return;
 
       isDrag = true;
@@ -211,17 +149,17 @@ const WebWindow = () => {
       positionX = event.target.offsetLeft;
       block.style.top = `${positionY}px`;
       block.style.left = `${positionX}px`;
-    });
+    };
 
-    window.addEventListener("mousemove", (event) => {
+    const windowMousemove = (event) => {
       if (!isScrapModeRef.current) return;
       if (!isDrag) return;
 
       block.style.top = `${event.clientY}px`;
       block.style.left = `${event.clientX}px`;
-    });
+    };
 
-    window.addEventListener("mouseup", (event) => {
+    const windowMouseup = (event) => {
       if (!isScrapModeRef.current) return;
       if (!isDrag) return;
 
@@ -234,7 +172,13 @@ const WebWindow = () => {
       }
 
       block.style.display = "none";
-    });
+    };
+
+    webWindowContent.addEventListener("mouseover", webWindowContentMouseover);
+    webWindowContent.addEventListener("mouseout", webWindowContentMouseout);
+    webWindow.addEventListener("mousedown", webWindowMousedown);
+    window.addEventListener("mousemove", windowMousemove);
+    window.addEventListener("mouseup", windowMouseup);
 
     (async () => {
       const url =
@@ -262,51 +206,17 @@ const WebWindow = () => {
         style={{ position: "absolute" }}
         dangerouslySetInnerHTML={{ __html: selectedBlock }}
       />
+      <AddressBarBox
+        isAddressBarFold={isAddressBarFold}
+        setIsAddressBarFold={setIsAddressBarFold}
+        setIframeDom={setIframeDom}
+      />
       <div
-        className="WebWindow-addressBarBox"
-        style={{
-          transform: isAddressBarFold ? "translateY(-70px)" : "translateY(0px)",
-        }}
-      >
-        <input
-          defaultValue={
-            getCookie("urlAddress") ||
-            urlAddress ||
-            "https://eye-catch-danke-foresight.w3spaces.com"
-          }
-          onChange={(event) => {
-            dispatch(setUrlAddress(event.target.value));
-          }}
-        />
-        <span
-          className="material-symbols-outlined WebWindow-changeUrlButton"
-          onClick={async () => {
-            const { data } = await axios.get(urlAddress);
-
-            setIframeDom(data);
-          }}
-        >
-          arrow_forward
-        </span>
-        <div
-          className="WebWindow-foldButton"
-          onClick={() => {
-            setIsAddressBarFold(!isAddressBarFold);
-          }}
-          style={{
-            transform: isAddressBarFold
-              ? "translateY(25px)"
-              : "translateY(-15px)",
-          }}
-        >
-          <span className="material-symbols-outlined">arrow_drop_up</span>
-          <span className="material-symbols-outlined">arrow_drop_down</span>
-        </div>
-      </div>
-      <div
-        className="WebWindow-scrapModeButton"
+        className={`WebWindow-scrapModeButton ${
+          isScrapMode && "WebWindow-scrapMode"
+        }`}
         onClick={() => {
-          isScrapModeRef.current = !isScrapModeRef.current;
+          setIsScrapMode(!isScrapMode);
         }}
       >
         <span className="material-symbols-outlined">file_copy</span>

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,11 +1,13 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import blocks from "./reducers/blocks";
+import selectedSidebarTool from "./reducers/selectedSidebarTool";
 import urlAddress from "./reducers/urlAddress";
 
 const store = configureStore({
   reducer: {
     urlAddress: urlAddress,
     blocks: blocks,
+    selectedSidebarTool: selectedSidebarTool,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,6 +1,7 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import blocks from "./reducers/blocks";
 import selectedSidebarTool from "./reducers/selectedSidebarTool";
+import selectModeOption from "./reducers/selectModeOption";
 import urlAddress from "./reducers/urlAddress";
 
 const store = configureStore({
@@ -8,6 +9,7 @@ const store = configureStore({
     urlAddress: urlAddress,
     blocks: blocks,
     selectedSidebarTool: selectedSidebarTool,
+    selectModeOption: selectModeOption,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/redux/reducers/selectModeOption.js
+++ b/src/redux/reducers/selectModeOption.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const selectModeOption = createSlice({
+  name: "selectModeOption",
+  initialState: {
+    selectModeOption: "BoxAndBlockMode",
+  },
+  reducers: {
+    changeSelectModeOption(state, action) {
+      state.selectModeOption = action.payload;
+    },
+  },
+});
+
+export const { changeSelectModeOption } = selectModeOption.actions;
+
+export default selectModeOption.reducer;

--- a/src/redux/reducers/selectedSidebarTool.js
+++ b/src/redux/reducers/selectedSidebarTool.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const selectedSidebarTool = createSlice({
+  name: "selectedSidebarTool",
+  initialState: {
+    selectedSidebarTool: null,
+  },
+  reducers: {
+    selectSidebarTool(state, action) {
+      state.selectedSidebarTool = action.payload;
+    },
+  },
+});
+
+export const { selectSidebarTool } = selectedSidebarTool.actions;
+
+export default selectedSidebarTool.reducer;

--- a/src/redux/reducers/urlAddress.js
+++ b/src/redux/reducers/urlAddress.js
@@ -3,7 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 export const urlAddress = createSlice({
   name: "urlAddress",
   initialState: {
-    urlAddress: "https://eye-catch-danke-foresight.w3spaces.com",
+    urlAddress: "https://illuminating-extol-innovation.w3spaces.com/",
   },
   reducers: {
     setUrlAddress(state, action) {


### PR DESCRIPTION
# Topic
- Web Window 드래그 앤 드랍 구현

# Detail

https://user-images.githubusercontent.com/99075014/202199028-b8bad96b-f049-4e01-bfd5-e8696a4a738c.mov

- 드래그 앤 드랍 기능 구현 완료.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Web-Window-28f502a8d8074691bfab446f9778fc61

# Kanban List
- [x]  유저는 Web Window의 Dom요소를 드래그 앤 드랍하여 Scrap Window로 옮길 수 있다.
    - [x]  오른쪽 하단에 위치한 Scrap Mode버튼을 클릭하여 
    Web Window의 Dom요소를 드래그 앤 드랍할 수 있는 Scrap Mode로 전환할 수 있다.
    - [x]  HTML Dom요소를 Scrap Window에 드래그 앤 드랍하면
    해당하는 위치의 Box 컴포넌트안에 Block 컴포넌트로 들어간다.
    - [x]  해당하는 위치에 Box가 없을경우 그 위치에 새로운 Box를 생성한 후 
    그 Box안에 포함시킨다.

# ETC
- 해당사항 없음