### PR TITLE
[2022.11.17] Web Window Select Mode 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.9.3",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.9.3",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.9.3",
+  "version": "0.10.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -62,6 +62,7 @@ const Box = styled.div`
   justify-content: flex-start;
   align-items: center;
   flex-direction: column;
+  margin: 5px 0;
   padding: 10px;
   width: 500px;
   border: 2px solid #ccc;
@@ -77,7 +78,6 @@ const ScrapWindow = () => {
     ({ selectModeOption }) => selectModeOption
   );
 
-  const [selectedBlock, setSelectedBlock] = useState(null);
   const [isFullScreen, setIsFullScreen] = useState(false);
 
   useEffect(() => {
@@ -119,23 +119,26 @@ const ScrapWindow = () => {
     };
 
     const scrapWindowContentMouseover = (event) => {
+      if (event.target === scrapWindow) return;
+
       event.target.classList.add("selectedDom");
     };
 
     const scrapWindowContentMouseout = (event) => {
+      if (event.target === scrapWindow) return;
+
       event.target.classList.remove("selectedDom");
     };
 
     const scrapWindowMousedown = (event) => {
+      if (event.target === scrapWindow) return;
+
       isDrag = true;
       selectedElement = event.target;
 
       selectedElement.style.position = "absolute";
       selectedElement.style.top = `${event.target.offsetTop}px`;
       selectedElement.style.left = `${event.target.offsetLeft}px`;
-      if (selectModeOptionRef.current === "BoxAndBlockMode") {
-      } else {
-      }
     };
 
     const scrapWindowMousemove = (event) => {
@@ -143,17 +146,17 @@ const ScrapWindow = () => {
 
       selectedElement.style.top = `${event.clientY}px`;
       selectedElement.style.left = `${event.clientX}px`;
-      if (selectModeOptionRef.current === "BoxAndBlockMode") {
-      } else {
-      }
     };
 
     const scrapWindowMouseup = (event) => {
       if (!isDrag) return;
 
-      isDrag = false;
-
       const boxes = document.getElementsByClassName("BoxComponent");
+      const copiedBox = boxes[0].cloneNode(false);
+
+      isDrag = false;
+      selectedElement.style.top = `${event.clientY}px`;
+      selectedElement.style.left = `${event.clientX}px`;
 
       if (selectModeOptionRef.current === "BoxAndBlockMode") {
         for (let i = 0; i < boxes.length; i++) {
@@ -168,12 +171,15 @@ const ScrapWindow = () => {
             selectedElement.style.removeProperty("left");
             boxes[i].insertAdjacentElement("beforeend", selectedElement);
 
-            break;
+            return;
           }
         }
-      } else {
-        selectedElement.style.top = `${event.clientY}px`;
-        selectedElement.style.left = `${event.clientX}px`;
+
+        selectedElement.style.position = "relative";
+        selectedElement.style.removeProperty("top");
+        selectedElement.style.removeProperty("left");
+        copiedBox.insertAdjacentElement("beforeend", selectedElement);
+        scrapWindow.insertAdjacentElement("beforeend", copiedBox);
       }
     };
 
@@ -189,11 +195,7 @@ const ScrapWindow = () => {
     <ScrapWindowContainer ref={resizableElementRef} className="resizable">
       <div id="scrapWindowContentBox" className="contentBox">
         <Box className="BoxComponent"></Box>
-        <Box className="BoxComponent">
-          {blocks.map((value, index) => {
-            return <Block html={value} key={index} />;
-          })}
-        </Box>
+        <Box className="BoxComponent"></Box>
       </div>
       <div ref={rightResizerRef} className="resizer-r"></div>
       <div

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
 import SIDEBAR_TOOLS from "../../constants/SIDEBAR_TOOLS";
+import { toggleModalOpen } from "../../redux/reducers/selectedSidebarTool";
 import { changeSelectModeOption } from "../../redux/reducers/selectModeOption";
 import SidebarFoldButton from "../SidebarFoldButton";
 import SidebarModal from "../SidebarModal";
@@ -48,6 +49,10 @@ const SidebarContainer = styled.div`
 
 const Sidebar = () => {
   const [isFold, setIsFold] = useState(false);
+
+  const { isSidebarModalOpen } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
 
   const dispatch = useDispatch();
 

--- a/src/containers/SidebarModal/index.jsx
+++ b/src/containers/SidebarModal/index.jsx
@@ -19,13 +19,17 @@ const SidebarModalContainer = styled.div`
 `;
 
 const SidebarModal = ({ content }) => {
-  const { selectedSidebarTool } = useSelector(
+  const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
     ({ selectedSidebarTool }) => selectedSidebarTool
   );
 
   return (
     <SidebarModalContainer
-      style={{ display: selectedSidebarTool !== "selectMode" && "none" }}
+      style={{
+        display:
+          (selectedSidebarTool !== "selectMode" || !isSidebarModalOpen) &&
+          "none",
+      }}
     >
       {content}
     </SidebarModalContainer>

--- a/src/containers/SidebarTool/index.jsx
+++ b/src/containers/SidebarTool/index.jsx
@@ -2,7 +2,10 @@ import React from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import COLORS from "../../constants/COLORS";
-import { selectSidebarTool } from "../../redux/reducers/selectedSidebarTool";
+import {
+  selectSidebarTool,
+  toggleModalOpen,
+} from "../../redux/reducers/selectedSidebarTool";
 
 const SidebarToolContainer = styled.div`
   display: flex;
@@ -29,7 +32,7 @@ const SidebarToolContainer = styled.div`
 `;
 
 const SidebarTool = ({ icon, mode }) => {
-  const { selectedSidebarTool } = useSelector(
+  const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
     ({ selectedSidebarTool }) => selectedSidebarTool
   );
 
@@ -39,7 +42,11 @@ const SidebarTool = ({ icon, mode }) => {
     <SidebarToolContainer
       className={selectedSidebarTool === mode && "Sidebar-selectedTool"}
       onClick={() => {
-        dispatch(selectSidebarTool(mode));
+        if (selectedSidebarTool !== mode) {
+          dispatch(selectSidebarTool(mode));
+        }
+
+        dispatch(toggleModalOpen(!isSidebarModalOpen));
       }}
     >
       <span className="material-symbols-outlined">{icon}</span>

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -163,13 +163,43 @@ const WebWindow = () => {
       if (!isScrapModeRef.current) return;
       if (!isDrag) return;
 
+      const boxes = document.getElementsByClassName("BoxComponent");
+      const scrapWindow = document.getElementById("scrapWindowContentBox");
+      const copiedBox = boxes[0].cloneNode(false);
+
       isDrag = false;
       block.style.top = `${event.clientY}px`;
       block.style.left = `${event.clientX}px`;
 
-      if (webWindow.offsetLeft > event.clientX) {
-        dispatch(addBlocks(selectedElement.outerHTML));
+      for (let i = 0; i < boxes.length; i++) {
+        if (
+          boxes[i].getBoundingClientRect().top < event.clientY &&
+          boxes[i].getBoundingClientRect().bottom > event.clientY &&
+          boxes[i].getBoundingClientRect().left < event.clientX &&
+          boxes[i].getBoundingClientRect().right > event.clientX
+        ) {
+          selectedElement.style.position = "relative";
+          selectedElement.style.removeProperty("top");
+          selectedElement.style.removeProperty("left");
+          boxes[i].insertAdjacentElement(
+            "beforeend",
+            selectedElement.cloneNode(true)
+          );
+
+          block.style.display = "none";
+          return;
+        }
       }
+
+      selectedElement.style.position = "relative";
+      selectedElement.style.removeProperty("top");
+      selectedElement.style.removeProperty("left");
+      copiedBox.insertAdjacentElement(
+        "beforeend",
+        selectedElement.cloneNode(true)
+      );
+
+      scrapWindow.insertAdjacentElement("beforeend", copiedBox);
 
       block.style.display = "none";
     };

--- a/src/redux/reducers/selectedSidebarTool.js
+++ b/src/redux/reducers/selectedSidebarTool.js
@@ -3,15 +3,20 @@ import { createSlice } from "@reduxjs/toolkit";
 export const selectedSidebarTool = createSlice({
   name: "selectedSidebarTool",
   initialState: {
-    selectedSidebarTool: null,
+    selectedSidebarTool: "null",
+    isSidebarModalOpen: false,
   },
   reducers: {
     selectSidebarTool(state, action) {
       state.selectedSidebarTool = action.payload;
     },
+    toggleModalOpen(state, action) {
+      state.isSidebarModalOpen = action.payload;
+    },
   },
 });
 
-export const { selectSidebarTool } = selectedSidebarTool.actions;
+export const { selectSidebarTool, toggleModalOpen } =
+  selectedSidebarTool.actions;
 
 export default selectedSidebarTool.reducer;


### PR DESCRIPTION
# Topic
- Web Window Select Mode 구현

# Detail

https://user-images.githubusercontent.com/99075014/202225916-bf359558-2728-4164-8600-72eebb14ba1f.mov

- Select Mode 구현 완료.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Select-Mode-7a955bcbf9da40ea9db0848cc4c980a0

# Kanban List
- [x]  Select Mode가 선택되면 Scrap Window에 존재하는 Box, Block의 위치를 재조립할 수 있다.
    - [x]  Block의 위치를 바꿀 수 있다.
    - [x]  Block을 다른 Box로 옮길 수 있다.
    - [x]  Box를 다른 Box안에 넣거나 뺄 수 있다.
    - [x]  선택된 Block을 자유이동 모드로 바꿀 수 있다.
        - [x]  Block, Box구조에 관계없이 해당 Block이 Scrap Window내에 자유롭게 위치할 수 있다.
# ETC
- 해당사항 없음