### PR TITLE
[2022.11.18] Web Window Edit Mode -  Image, Video 크기 수정 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.11.3",
+  "version": "0.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.11.3",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.11.3",
+  "version": "0.12.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -141,17 +141,12 @@ const ScrapWindow = () => {
       if (event.target === scrapWindow) return;
 
       selectedElement = event.target;
+      isDrag = true;
 
       if (selectedSidebarToolRef.current === "selectMode") {
-        isDrag = true;
-
         selectedElement.style.position = "absolute";
-        selectedElement.style.top = `${
-          event.target.getBoundingClientRect().bottom
-        }px`;
-        selectedElement.style.left = `${
-          event.target.getBoundingClientRect().left
-        }px`;
+        selectedElement.style.top = `${event.clientY}px`;
+        selectedElement.style.left = `${event.clientX}px`;
       } else if (selectedSidebarToolRef.current === "editMode") {
       }
     };
@@ -162,13 +157,24 @@ const ScrapWindow = () => {
 
         selectedElement.style.top = `${event.clientY}px`;
         selectedElement.style.left = `${event.clientX}px`;
+      } else if (selectedSidebarToolRef.current === "editMode") {
+        if (
+          selectedElement.tagName === "IMG" ||
+          selectedElement.tagName === "VIDEO"
+        ) {
+          selectedElement.style.width = `${
+            event.clientX - selectedElement.getBoundingClientRect().left
+          }px`;
+        }
       }
     };
 
     const scrapWindowMouseup = (event) => {
-      if (selectedSidebarToolRef.current === "selectMode") {
-        if (!isDrag) return;
+      if (!isDrag) return;
 
+      isDrag = false;
+
+      if (selectedSidebarToolRef.current === "selectMode") {
         const boxes = document.getElementsByClassName("BoxComponent");
         const copiedBox = boxes[0].cloneNode(false);
 
@@ -178,7 +184,6 @@ const ScrapWindow = () => {
           );
         }
 
-        isDrag = false;
         selectedElement.style.top = `${event.clientY}px`;
         selectedElement.style.left = `${event.clientX}px`;
 
@@ -212,6 +217,8 @@ const ScrapWindow = () => {
         }
       } else if (selectedSidebarToolRef.current === "editMode") {
       }
+
+      selectedElement = null;
     };
 
     resizerRight.addEventListener("mousedown", onMouseDownRightResize);

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
 import SIDEBAR_TOOLS from "../../constants/SIDEBAR_TOOLS";
-import { toggleModalOpen } from "../../redux/reducers/selectedSidebarTool";
 import { changeSidebarModeOption } from "../../redux/reducers/sidebarModeOption";
 import SidebarFoldButton from "../SidebarFoldButton";
 import SidebarModal from "../SidebarModal";

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -120,8 +120,6 @@ const WebWindow = () => {
 
     let isDrag = false;
     let selectedElement;
-    let positionX = 0;
-    let positionY = 0;
 
     const webWindowContentMouseover = (event) => {
       if (!isScrapModeRef.current) return;
@@ -139,15 +137,14 @@ const WebWindow = () => {
       if (!isScrapModeRef.current) return;
 
       isDrag = true;
-      block.style.display = "flex";
       selectedElement = event.target;
+
+      block.style.display = "flex";
 
       setSelectedBlock(selectedElement.outerHTML);
 
-      positionY = event.target.getBoundingClientRect().top;
-      positionX = event.target.getBoundingClientRect().left;
-      block.style.top = `${positionY}px`;
-      block.style.left = `${positionX}px`;
+      block.style.top = `${event.clientY}px`;
+      block.style.left = `${event.clientX}px`;
     };
 
     const windowMousemove = (event) => {
@@ -167,6 +164,7 @@ const WebWindow = () => {
       const copiedBox = boxes[0].cloneNode(false);
 
       isDrag = false;
+
       block.style.top = `${event.clientY}px`;
       block.style.left = `${event.clientX}px`;
 


### PR DESCRIPTION
# Topic
- Web Window Edit Mode - Text 구현

# Detail

https://user-images.githubusercontent.com/99075014/202489336-03075e77-bd72-4324-adbe-b39558b6ee68.mov

- Web Window Edit Mode의 기능 중 Image와 Video의 크기를 수정하는 기능 구현

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Edit-Mode-Image-Video-cb78204c22724cbc8fd23ced2a4ed53c

# Kanban List
- [x]  유저는 Sidebar에서 Edit Mode 아이콘을 클릭할 수 있다.
    - [x]  Edit Mode가 선택되면 Block의 내용을 수정할 수 있다.
    - [x]  Block을 클릭하면 해당 유형에 맞는 ToolBox가 나타난다.
- [x]  Image로된 Block Edit 기능.
    - [x]  Image의 크기를 조절할 수 있다. 
    (Image의 크기는 원본 비율을 유지한채로 조절된다.)
- [x]  Video로된 Block Edit 기능.
    - [x]  Video의 크기를 조절할 수 있다. 
    (Video의 크기는 원본 비율을 유지한채로 조절된다.)

# ETC
- 해당사항 없음