### PR TITLE
[2022.11.19] Pen, Highlighter 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.14.1",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.14.1",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.14.1",
+  "version": "0.15.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/Drawing/index.jsx
+++ b/src/containers/Drawing/index.jsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  drawLineWithPen,
+  drawLineWithHighlighter,
+} from "../../../utils/drawLine";
+
+const Drawing = () => {
+  const selectedSidebarToolRef = useRef(false);
+  const sidebarModeOptionRef = useRef(null);
+  const canvasRef = useRef(null);
+  const lineOpacityRef = useRef(null);
+  const lineWidthRef = useRef(null);
+  const lineColorRef = useRef(null);
+
+  const { lineColor, lineWidth, lineOpacity } = useSelector(
+    ({ lineStyle }) => lineStyle
+  );
+  const { selectedSidebarTool } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  const { sidebarModeOption } = useSelector(
+    ({ sidebarModeOption }) => sidebarModeOption
+  );
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    selectedSidebarToolRef.current = selectedSidebarTool;
+  }, [selectedSidebarTool]);
+
+  useEffect(() => {
+    sidebarModeOptionRef.current = sidebarModeOption;
+  }, [sidebarModeOption]);
+
+  useEffect(() => {
+    lineOpacityRef.current = lineOpacity;
+  }, [lineOpacity]);
+
+  useEffect(() => {
+    lineWidthRef.current = lineWidth;
+  }, [lineWidth]);
+
+  useEffect(() => {
+    lineColorRef.current = lineColor;
+  }, [lineColor]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas.getContext("2d");
+    const drawingModeModal = document.getElementById("drawingModeModal");
+    const widthChange = document.getElementById("widthChange");
+    const opacityChange = document.getElementById("opacityChange");
+    const colorChange = document.getElementById("colorChange");
+    const scrapWindow = document.getElementById("scrapWindowContentBox");
+
+    let drawing = false;
+    let highlighterEndPosition;
+    let startPosition;
+
+    const onMouseDown = (event) => {
+      if (
+        selectedSidebarToolRef.current !== "drawingMode" ||
+        event.target === drawingModeModal ||
+        event.target === widthChange ||
+        event.target === opacityChange ||
+        event.target === colorChange
+      )
+        return;
+
+      drawing = true;
+      startPosition = [event.clientX, event.clientY];
+      highlighterEndPosition = event.clientY;
+    };
+
+    const onMouseMove = (event) => {
+      if (!drawing) {
+        return;
+      }
+
+      if (sidebarModeOptionRef.current === "Pen") {
+        drawLineWithPen(
+          context,
+          startPosition,
+          [event.clientX, event.clientY],
+          lineColorRef.current,
+          lineWidthRef.current
+        );
+
+        startPosition = [event.clientX, event.clientY];
+      } else if (sidebarModeOptionRef.current === "Highlighter") {
+        drawLineWithHighlighter(
+          context,
+          startPosition,
+          [event.clientX, highlighterEndPosition],
+          lineColorRef.current,
+          lineWidthRef.current,
+          lineOpacityRef.current
+        );
+
+        startPosition = [event.clientX, startPosition[1]];
+      }
+    };
+
+    const onMouseUp = (event) => {
+      if (!drawing) {
+        return;
+      }
+
+      drawing = false;
+
+      if (sidebarModeOptionRef.current === "Pen") {
+        drawLineWithPen(
+          context,
+          startPosition,
+          [event.clientX, event.clientY],
+          lineColorRef.current,
+          lineWidthRef.current
+        );
+      } else if (sidebarModeOptionRef.current === "Highlighter") {
+        drawLineWithHighlighter(
+          context,
+          startPosition,
+          [event.clientX, highlighterEndPosition],
+          lineColorRef.current,
+          lineWidthRef.current
+        );
+      }
+    };
+
+    window.addEventListener("mousedown", onMouseDown, false);
+    window.addEventListener("mouseup", onMouseUp, false);
+    window.addEventListener("mouseout", onMouseUp, false);
+    window.addEventListener("mousemove", onMouseMove, false);
+
+    const onResize = () => {
+      canvas.width = scrapWindow.offsetWidth + 70;
+      canvas.height = scrapWindow.offsetHeight;
+    };
+
+    scrapWindow.addEventListener("change", onResize, false);
+    onResize();
+  }, []);
+
+  return (
+    <DrawingContainer>
+      <canvas
+        ref={canvasRef}
+        id="drawingCanvas"
+        style={{
+          zIndex: selectedSidebarToolRef.current === "drawingMode" ? "1" : "-1",
+        }}
+      />
+    </DrawingContainer>
+  );
+};
+
+const DrawingContainer = styled.div`
+  canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    user-select: none;
+  }
+`;
+
+export default Drawing;

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import hasClass from "../../../utils/hasClass";
 import isMouseOn from "../../../utils/isMouseOn";
 import COLORS from "../../constants/COLORS";
+import Drawing from "../Drawing";
 import EditModal from "../EditModeModal";
 
 const ScrapWindowContainer = styled.div`
@@ -100,6 +101,7 @@ const ScrapWindow = () => {
     const webWindow = document.getElementById("webWindow");
     const scrapWindow = document.getElementById("scrapWindowContentBox");
     const editModal = document.getElementById("editModal");
+    const drawingCanvas = document.getElementById("drawingCanvas");
 
     let isDrag = false;
     let selectedElement;
@@ -129,19 +131,30 @@ const ScrapWindow = () => {
     };
 
     const scrapWindowContentMouseover = (event) => {
-      if (event.target === scrapWindow || isMouseOn(editModal)) return;
+      if (
+        event.target === scrapWindow ||
+        isMouseOn(editModal) ||
+        selectedSidebarToolRef.current === "drawingMode"
+      )
+        return;
 
       event.target.classList.add("selectedDom");
     };
 
     const scrapWindowContentMouseout = (event) => {
-      if (event.target === scrapWindow || isMouseOn(editModal)) return;
+      if (
+        event.target === scrapWindow ||
+        isMouseOn(editModal) ||
+        selectedSidebarToolRef.current === "drawingMode"
+      )
+        return;
 
       event.target.classList.remove("selectedDom");
     };
 
     const scrapWindowMousedown = (event) => {
-      if (event.target === scrapWindow) return;
+      if (event.target === scrapWindow || event.target === drawingCanvas)
+        return;
 
       selectedElement = event.target;
       isDrag = true;
@@ -231,6 +244,7 @@ const ScrapWindow = () => {
       >
         <Box className="BoxComponent"></Box>
         <EditModal />
+        <Drawing />
       </div>
       <div ref={rightResizerRef} className="resizer-r"></div>
       <div

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -6,6 +6,7 @@ import COLORS from "../../constants/COLORS";
 import SIDEBAR_TOOLS from "../../constants/SIDEBAR_TOOLS";
 import { changeSidebarModeOption } from "../../redux/reducers/sidebarModeOption";
 import SidebarBoxModeModal from "../SidebarBoxModeModal";
+import SidebarDrawingModeModal from "../SidebarDrawingModeModal";
 import SidebarFoldButton from "../SidebarFoldButton";
 import SidebarSelectModeModal from "../SidebarSelectModeModal";
 import SidebarTool from "../SidebarTool";
@@ -38,6 +39,7 @@ const Sidebar = () => {
     >
       <SidebarSelectModeModal />
       <SidebarBoxModeModal />
+      <SidebarDrawingModeModal />
       {SIDEBAR_TOOLS.map((value, index) => {
         return <SidebarTool icon={value.ICON} mode={value.MODE} key={index} />;
       })}

--- a/src/containers/SidebarDrawingModeModal/index.jsx
+++ b/src/containers/SidebarDrawingModeModal/index.jsx
@@ -1,0 +1,201 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import COLORS from "../../constants/COLORS";
+import {
+  setLineColor,
+  setLineOpacity,
+  setLineWidth,
+} from "../../redux/reducers/lineStyle";
+import { changeSidebarModeOption } from "../../redux/reducers/sidebarModeOption";
+
+const SidebarDrawingModeModalContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 20px 30px;
+  top: 25vh;
+  left: 90px;
+  min-width: 250px;
+  background-color: ${COLORS.SUB_COLOR};
+  border: 2px solid ${COLORS.MAIN_COLOR};
+  border-radius: 5px;
+
+  .sidebarModeOption {
+    margin: 5px 0px;
+    padding: 3px 10px;
+    text-align: center;
+    background-color: ${COLORS.SUB_COLOR};
+    border: 1px solid ${COLORS.MAIN_COLOR};
+    border-radius: 5px;
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+
+    :hover {
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+    }
+
+    :active {
+      opacity: 0.4;
+    }
+  }
+
+  .selected {
+    color: ${COLORS.SUB_COLOR};
+    background-color: ${COLORS.MAIN_COLOR};
+  }
+
+  .selectPenBox {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 20px;
+    width: 100%;
+
+    div {
+      margin: 0 2px;
+      padding: 2px 10px;
+      min-width: 80px;
+      text-align: center;
+      border: 2px solid ${COLORS.MAIN_COLOR};
+      border-radius: 2px;
+    }
+  }
+
+  .drawingOptionBox {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    margin: 30px 0;
+  }
+
+  .drawingOption {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    width: 200px;
+
+    p {
+      width: 80px;
+      text-align: center;
+    }
+
+    input {
+      width: 120px;
+    }
+  }
+`;
+
+const SidebarDrawingModeModal = () => {
+  const { lineWidth, lineOpacity } = useSelector(({ lineStyle }) => lineStyle);
+  const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  const [selectedMode, setSelectedMode] = useState(null);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const scrapWindow = document.getElementById("scrapWindowContentBox");
+
+    scrapWindow.addEventListener("mousedown", (event) => {
+      setSelectedElement(event.target);
+    });
+  }, []);
+
+  return (
+    <SidebarDrawingModeModalContainer
+      id="drawingModeModal"
+      style={{
+        display:
+          (selectedSidebarTool !== "drawingMode" || !isSidebarModalOpen) &&
+          "none",
+      }}
+    >
+      <h3>Drawing Mode</h3>
+      <div className="selectPenBox">
+        <div
+          className={`sidebarModeOption ${
+            selectedMode === "pen" && "selected"
+          }`}
+          onClick={() => {
+            dispatch(changeSidebarModeOption("Pen"));
+            setSelectedMode("pen");
+          }}
+        >
+          Pen
+        </div>
+        <div
+          className={`sidebarModeOption ${
+            selectedMode === "highlighter" && "selected"
+          }`}
+          onClick={() => {
+            dispatch(changeSidebarModeOption("Highlighter"));
+            setSelectedMode("highlighter");
+          }}
+        >
+          Highlighter
+        </div>
+        <div
+          className={`sidebarModeOption ${
+            selectedMode === "eraser" && "selected"
+          }`}
+          onClick={() => {
+            dispatch(changeSidebarModeOption("Eraser"));
+            setSelectedMode("eraser");
+          }}
+        >
+          Eraser
+        </div>
+      </div>
+      <div className="drawingOptionBox">
+        <div className="drawingOption">
+          <p>Width</p>
+          <input
+            id="widthChange"
+            type="range"
+            min="1"
+            max="50"
+            defaultValue="3"
+            onChange={(event) => {
+              dispatch(setLineWidth(event.target.value));
+            }}
+          />
+          <div>{lineWidth}</div>
+        </div>
+        <div className="drawingOption">
+          <p>Opacity</p>
+          <input
+            id="opacityChange"
+            type="range"
+            min="10"
+            max="100"
+            defaultValue="10"
+            onChange={(event) => {
+              dispatch(setLineOpacity(event.target.value));
+            }}
+          />
+          <div>{lineOpacity}</div>
+        </div>
+        <div className="drawingOption">
+          <p>Color</p>
+          <input
+            id="colorChange"
+            type="color"
+            onChange={(event) => {
+              dispatch(setLineColor(event.target.value));
+            }}
+          />
+        </div>
+      </div>
+    </SidebarDrawingModeModalContainer>
+  );
+};
+
+export default SidebarDrawingModeModal;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,5 +1,6 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import blocks from "./reducers/blocks";
+import lineStyle from "./reducers/lineStyle";
 import selectedSidebarTool from "./reducers/selectedSidebarTool";
 import sidebarModeOption from "./reducers/sidebarModeOption";
 
@@ -11,6 +12,7 @@ const store = configureStore({
     blocks: blocks,
     selectedSidebarTool: selectedSidebarTool,
     sidebarModeOption: sidebarModeOption,
+    lineStyle: lineStyle,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/redux/reducers/lineStyle.js
+++ b/src/redux/reducers/lineStyle.js
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const lineStyle = createSlice({
+  name: "lineStyle",
+  initialState: {
+    lineColor: "black",
+    lineWidth: 3,
+    lineOpacity: 20,
+  },
+  reducers: {
+    setLineColor(state, action) {
+      state.lineColor = action.payload;
+    },
+    setLineWidth(state, action) {
+      state.lineWidth = action.payload;
+    },
+    setLineOpacity(state, action) {
+      state.lineOpacity = action.payload;
+    },
+  },
+});
+
+export const { setLineColor, setLineWidth, setLineOpacity } = lineStyle.actions;
+
+export default lineStyle.reducer;

--- a/utils/drawLine.js
+++ b/utils/drawLine.js
@@ -1,0 +1,36 @@
+export const drawLineWithPen = (
+  context,
+  startPosition,
+  endPosition,
+  color,
+  width
+) => {
+  context.beginPath();
+  context.moveTo(...startPosition);
+  context.lineTo(...endPosition);
+  context.strokeStyle = color;
+  context.lineWidth = width;
+  context.lineCap = "round";
+  context.globalAlpha = 1;
+  context.stroke();
+  context.closePath();
+};
+
+export const drawLineWithHighlighter = (
+  context,
+  startPosition,
+  endPosition,
+  color,
+  width,
+  opacity
+) => {
+  context.beginPath();
+  context.moveTo(...startPosition);
+  context.lineTo(...endPosition);
+  context.strokeStyle = color;
+  context.lineWidth = width;
+  context.lineCap = "butt";
+  context.globalAlpha = opacity * 0.01;
+  context.stroke();
+  context.closePath();
+};


### PR DESCRIPTION
# Topic
- Pen, Highlighter 구현

# Detail

https://user-images.githubusercontent.com/99075014/202752140-1e8d3e6d-0237-43f6-98c0-235ca3a286a6.mov

- 유저는 Pen으로 Scrap Window에 선을 그릴 수 있다.
- 유저는 Highlighter로 Scrap Window에 강조선을 그릴 수 있다.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Drawing-Mode-Pen-Highlighter-6e31887fb3b1437cb0736d2620936a70

# Kanban List
- [x]  유저는 Sidebar에서 Drawing Mode 아이콘을 클릭할 수 있다.
    - [x]  Drawing Mode가 선택되면 Sidebar에 Modal이 나타난다.
    - [x]  Modal에서 원하는 Pen 종류를 선택할 수 있다.
        1. Pen: 일반적인 둥근 모양의 Pen.
        2. Highlighter: Text를 강조할 수 있는 막대모양의 Pen.
    - [x]  Modal에서 Pen 종류에 따라 다음과 같은 Option을 설정할 수 있다.
        1. Pen: 펜 굵기, 색상
        2. Highlighter: 펜 위아래 길이, 색상, 불투명도

# ETC
- 해당사항 없음