### PR TITLE
[2022.11.19] 지우개 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.15.1",
+  "version": "0.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.15.1",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.15.1",
+  "version": "0.16.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/Drawing/index.jsx
+++ b/src/containers/Drawing/index.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import {
   drawLineWithPen,
   drawLineWithHighlighter,
+  drawLineWithEraser,
 } from "../../../utils/drawLine";
+import hasClass from "../../../utils/hasClass";
 
 const Drawing = () => {
   const selectedSidebarToolRef = useRef(false);
@@ -24,8 +26,6 @@ const Drawing = () => {
   const { sidebarModeOption } = useSelector(
     ({ sidebarModeOption }) => sidebarModeOption
   );
-
-  const dispatch = useDispatch();
 
   useEffect(() => {
     selectedSidebarToolRef.current = selectedSidebarTool;
@@ -50,10 +50,6 @@ const Drawing = () => {
   useEffect(() => {
     const canvas = canvasRef.current;
     const context = canvas.getContext("2d");
-    const drawingModeModal = document.getElementById("drawingModeModal");
-    const widthChange = document.getElementById("widthChange");
-    const opacityChange = document.getElementById("opacityChange");
-    const colorChange = document.getElementById("colorChange");
     const scrapWindow = document.getElementById("scrapWindowContentBox");
 
     let drawing = false;
@@ -63,10 +59,7 @@ const Drawing = () => {
     const onMouseDown = (event) => {
       if (
         selectedSidebarToolRef.current !== "drawingMode" ||
-        event.target === drawingModeModal ||
-        event.target === widthChange ||
-        event.target === opacityChange ||
-        event.target === colorChange
+        hasClass(event.target, "ignoreClick")
       )
         return;
 
@@ -101,6 +94,16 @@ const Drawing = () => {
         );
 
         startPosition = [event.clientX, startPosition[1]];
+      } else if (sidebarModeOptionRef.current === "Eraser") {
+        drawLineWithEraser(
+          context,
+          startPosition,
+          [event.clientX, event.clientY],
+          lineColorRef.current,
+          lineWidthRef.current
+        );
+
+        startPosition = [event.clientX, event.clientY];
       }
     };
 
@@ -124,6 +127,14 @@ const Drawing = () => {
           context,
           startPosition,
           [event.clientX, highlighterEndPosition],
+          lineColorRef.current,
+          lineWidthRef.current
+        );
+      } else if (sidebarModeOptionRef.current === "Eraser") {
+        drawLineWithEraser(
+          context,
+          startPosition,
+          [event.clientX, event.clientY],
           lineColorRef.current,
           lineWidthRef.current
         );

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -163,7 +163,6 @@ const ScrapWindow = () => {
         selectedElement.style.position = "absolute";
         selectedElement.style.top = `${event.clientY}px`;
         selectedElement.style.left = `${event.clientX}px`;
-      } else if (selectedSidebarToolRef.current === "editMode") {
       }
     };
 
@@ -198,29 +197,21 @@ const ScrapWindow = () => {
         selectedElement.style.left = `${event.clientX}px`;
 
         if (sidebarModeOptionRef.current === "BoxAndBlockMode") {
-          for (let i = 0; i < boxes.length; i++) {
-            if (isMouseOn(boxes[i])) {
-              selectedElement.style.position = "relative";
-              selectedElement.style.removeProperty("top");
-              selectedElement.style.removeProperty("left");
-              boxes[i].insertAdjacentElement("beforeend", selectedElement);
-
-              return;
+          if (event.target === scrapWindow) {
+            if (hasClass(selectedElement, "BoxComponent")) {
+              scrapWindow.insertAdjacentElement("beforeend", selectedElement);
+            } else {
+              copiedBox.insertAdjacentElement("beforeend", selectedElement);
+              scrapWindow.insertAdjacentElement("beforeend", copiedBox);
             }
-          }
-
-          if (hasClass(selectedElement, "BoxComponent")) {
-            scrapWindow.insertAdjacentElement("beforeend", selectedElement);
           } else {
-            copiedBox.insertAdjacentElement("beforeend", selectedElement);
-            scrapWindow.insertAdjacentElement("beforeend", copiedBox);
+            event.target.insertAdjacentElement("beforeend", selectedElement);
           }
 
           selectedElement.style.position = "relative";
           selectedElement.style.removeProperty("top");
           selectedElement.style.removeProperty("left");
         }
-      } else if (selectedSidebarToolRef.current === "editMode") {
       }
 
       selectedElement = null;

--- a/src/containers/SidebarBoxModeModal/index.jsx
+++ b/src/containers/SidebarBoxModeModal/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
+import hasClass from "../../../utils/hasClass";
 import COLORS from "../../constants/COLORS";
 
 const SidebarBoxModeModalContainer = styled.div`
@@ -153,7 +154,19 @@ const SidebarBoxModeModal = () => {
           scrapWindow.insertAdjacentElement("beforeend", copiedBox);
         }}
       >
-        Add Box
+        Add
+      </div>
+      <hr />
+      <h4>Delete Box</h4>
+      <div
+        className="sidebarModeOption"
+        onClick={() => {
+          if (hasClass(selectedElement, "BoxComponent")) {
+            selectedElement.remove();
+          }
+        }}
+      >
+        Delete
       </div>
       <hr />
       <div className="sortContainer">

--- a/src/containers/SidebarDrawingModeModal/index.jsx
+++ b/src/containers/SidebarDrawingModeModal/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import COLORS from "../../constants/COLORS";
@@ -96,18 +96,13 @@ const SidebarDrawingModeModal = () => {
   const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
     ({ selectedSidebarTool }) => selectedSidebarTool
   );
+  const { sidebarModeOption } = useSelector(
+    ({ sidebarModeOption }) => sidebarModeOption
+  );
 
   const [selectedMode, setSelectedMode] = useState(null);
 
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    const scrapWindow = document.getElementById("scrapWindowContentBox");
-
-    scrapWindow.addEventListener("mousedown", (event) => {
-      setSelectedElement(event.target);
-    });
-  }, []);
 
   return (
     <SidebarDrawingModeModalContainer
@@ -121,7 +116,7 @@ const SidebarDrawingModeModal = () => {
       <h3>Drawing Mode</h3>
       <div className="selectPenBox">
         <div
-          className={`sidebarModeOption ${
+          className={`sidebarModeOption ignoreClick ${
             selectedMode === "pen" && "selected"
           }`}
           onClick={() => {
@@ -132,7 +127,7 @@ const SidebarDrawingModeModal = () => {
           Pen
         </div>
         <div
-          className={`sidebarModeOption ${
+          className={`sidebarModeOption ignoreClick ${
             selectedMode === "highlighter" && "selected"
           }`}
           onClick={() => {
@@ -143,7 +138,7 @@ const SidebarDrawingModeModal = () => {
           Highlighter
         </div>
         <div
-          className={`sidebarModeOption ${
+          className={`sidebarModeOption ignoreClick ${
             selectedMode === "eraser" && "selected"
           }`}
           onClick={() => {
@@ -158,7 +153,7 @@ const SidebarDrawingModeModal = () => {
         <div className="drawingOption">
           <p>Width</p>
           <input
-            id="widthChange"
+            className="ignoreClick"
             type="range"
             min="1"
             max="50"
@@ -169,10 +164,15 @@ const SidebarDrawingModeModal = () => {
           />
           <div>{lineWidth}</div>
         </div>
-        <div className="drawingOption">
+        <div
+          className="drawingOption"
+          style={{
+            display: sidebarModeOption !== "Highlighter" && "none",
+          }}
+        >
           <p>Opacity</p>
           <input
-            id="opacityChange"
+            className="ignoreClick"
             type="range"
             min="10"
             max="100"
@@ -183,10 +183,15 @@ const SidebarDrawingModeModal = () => {
           />
           <div>{lineOpacity}</div>
         </div>
-        <div className="drawingOption">
+        <div
+          className="drawingOption"
+          style={{
+            display: sidebarModeOption === "Eraser" && "none",
+          }}
+        >
           <p>Color</p>
           <input
-            id="colorChange"
+            className="ignoreClick"
             type="color"
             onChange={(event) => {
               dispatch(setLineColor(event.target.value));

--- a/utils/drawLine.js
+++ b/utils/drawLine.js
@@ -5,6 +5,7 @@ export const drawLineWithPen = (
   color,
   width
 ) => {
+  context.globalCompositeOperation = "source-over";
   context.beginPath();
   context.moveTo(...startPosition);
   context.lineTo(...endPosition);
@@ -24,6 +25,7 @@ export const drawLineWithHighlighter = (
   width,
   opacity
 ) => {
+  context.globalCompositeOperation = "source-over";
   context.beginPath();
   context.moveTo(...startPosition);
   context.lineTo(...endPosition);
@@ -31,6 +33,25 @@ export const drawLineWithHighlighter = (
   context.lineWidth = width;
   context.lineCap = "butt";
   context.globalAlpha = opacity * 0.01;
+  context.stroke();
+  context.closePath();
+};
+
+export const drawLineWithEraser = (
+  context,
+  startPosition,
+  endPosition,
+  color,
+  width
+) => {
+  context.globalCompositeOperation = "destination-out";
+  context.beginPath();
+  context.moveTo(...startPosition);
+  context.lineTo(...endPosition);
+  context.strokeStyle = color;
+  context.lineWidth = width;
+  context.lineCap = "round";
+  context.globalAlpha = 1;
   context.stroke();
   context.closePath();
 };


### PR DESCRIPTION
# Topic
- 지우개 구현

# Detail

https://user-images.githubusercontent.com/99075014/202838614-70acf71c-a942-4eea-810f-0c2e6f0aebb8.mov

- 유저는 Eraser로 Scrap Window에 선과 강조선을 지울 수 있다.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Drawing-Mode-Eraser-1ae9ed7fd3ce45c997cc9f017d69fe97

# Kanban List
- [x]  유저는 Sidebar에서 Drawing Mode 아이콘을 클릭할 수 있다.
    - [x]  Drawing Mode가 선택되면 Sidebar에 Modal이 나타난다.
    - [x]  Modal에서 지우개를 선택해 Pen을 지울 수 있다.
        1. 지우개를 선택해 Pen을 직접 지울 수 있다.
        2. 모두 지우기 버튼을 눌러 모든 Pen을 지울 수 있다.

# ETC
- 해당사항 없음