### PR TITLE
[2022.11.20] Save Mode 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.17.1",
+  "version": "0.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.17.1",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.17.1",
+  "version": "0.18.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {
@@ -20,6 +20,7 @@
     "react-dom": "^17.0.2",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^8.0.5",
+    "react-to-print": "^2.14.10",
     "socket.io-client": "^4.5.3",
     "styled-components": "^5.3.6"
   },

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -8,6 +8,7 @@ import { changeSidebarModeOption } from "../../redux/reducers/sidebarModeOption"
 import SidebarBoxModeModal from "../SidebarBoxModeModal";
 import SidebarDrawingModeModal from "../SidebarDrawingModeModal";
 import SidebarFoldButton from "../SidebarFoldButton";
+import SidebarSaveModeModal from "../SidebarSaveModeModal";
 import SidebarSelectModeModal from "../SidebarSelectModeModal";
 import SidebarTool from "../SidebarTool";
 
@@ -40,6 +41,7 @@ const Sidebar = () => {
       <SidebarSelectModeModal />
       <SidebarBoxModeModal />
       <SidebarDrawingModeModal />
+      <SidebarSaveModeModal />
       {SIDEBAR_TOOLS.map((value, index) => {
         return <SidebarTool icon={value.ICON} mode={value.MODE} key={index} />;
       })}

--- a/src/containers/SidebarSaveModeModal/index.jsx
+++ b/src/containers/SidebarSaveModeModal/index.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import styled from "styled-components";
+import ReactToPrint from "react-to-print";
+import COLORS from "../../constants/COLORS";
+
+const SidebarSaveModeModalContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 20px 30px;
+  top: 60vh;
+  left: 90px;
+  min-width: 250px;
+  background-color: ${COLORS.SUB_COLOR};
+  border: 2px solid ${COLORS.MAIN_COLOR};
+  border-radius: 5px;
+
+  .sidebarModeOption {
+    margin: 5px 0px;
+    padding: 3px 10px;
+    text-align: center;
+    background-color: ${COLORS.SUB_COLOR};
+    border: 1px solid ${COLORS.MAIN_COLOR};
+    border-radius: 5px;
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+
+    :hover {
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+    }
+
+    :active {
+      opacity: 0.4;
+    }
+  }
+
+  .selected {
+    color: ${COLORS.SUB_COLOR};
+    background-color: ${COLORS.MAIN_COLOR};
+  }
+
+  @page {
+    size: A4;
+    margin: 20mm;
+  }
+`;
+
+const SidebarSaveModeModal = () => {
+  const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  return (
+    <SidebarSaveModeModalContainer
+      style={{
+        display:
+          (selectedSidebarTool !== "saveMode" || !isSidebarModalOpen) && "none",
+      }}
+    >
+      <h3>Save Mode</h3>
+
+      <ReactToPrint
+        trigger={() => (
+          <div className="sidebarModeOption" onClick={() => {}}>
+            Save Scrap Window
+          </div>
+        )}
+        content={() => document.getElementById("scrapWindowContentBox")}
+      />
+    </SidebarSaveModeModalContainer>
+  );
+};
+
+export default SidebarSaveModeModal;

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -144,6 +144,8 @@ const WebWindow = () => {
       selectedElement = event.target;
 
       block.style.display = "flex";
+      block.style.position = "absolute";
+      block.style.zIndex = "1000000";
 
       setSelectedBlock(selectedElement.outerHTML);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5271,6 +5271,13 @@ react-redux@^8.0.5:
     react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
 
+react-to-print@^2.14.10:
+  version "2.14.10"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.14.10.tgz#f063bb368c2d8926012d52780a2b983e91c3a797"
+  integrity sha512-XJyhDWH/xxgHy5nIBYPXjVidoroq0qRHqTrVF5QbfohPkMx3q8x3H3+Lv7gSq9uA0csAbjkSU0J4mWgj64f6yQ==
+  dependencies:
+    prop-types "^15.8.1"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"


### PR DESCRIPTION
# Topic
- Save Mode 구현

# Detail

https://user-images.githubusercontent.com/99075014/202899134-60aa1363-c7d8-4370-8f4a-e7800492a6b7.mov

- 유저가 Scrap Window의 내용을 PDF로 저장 또는 프린트할 수 있는 기능 구현

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Save-Mode-aa43961df64142da910e37f3f3f04f9c

# Kanban List
- [x]  유저는 Sidebar에서 Save Mode 아이콘을 클릭할 수 있다.
    1. Save Mode를 누르면 Print창이 나타난다.
    2. Print창에서 현재 Scrap Window를 PDF로 저장 및 Print를 할 수 있다.

# ETC
- 해당사항 없음