### PR TITLE
[2022.11.20] Theme Mode 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.18.1",
+  "version": "0.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.18.1",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.18.1",
+  "version": "0.19.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/constants/THEME.js
+++ b/src/constants/THEME.js
@@ -1,0 +1,27 @@
+export default {
+  DARK: {
+    FONT_COLOR: "#ffffff",
+    BACKGROUND_COLOR: "#373737",
+    BOX_BORDER: "#cccccc",
+  },
+  BROWN: {
+    FONT_COLOR: "#131313",
+    BACKGROUND_COLOR: "#ebd8c3",
+    BOX_BORDER: "#525252",
+  },
+  BLUE: {
+    FONT_COLOR: "#f9f7f7",
+    BACKGROUND_COLOR: "#aebdca",
+    BOX_BORDER: "#525252",
+  },
+  SKY_BLUE: {
+    FONT_COLOR: "#131313",
+    BACKGROUND_COLOR: "#e3fdfd",
+    BOX_BORDER: "#525252",
+  },
+  GREEN: {
+    FONT_COLOR: "#131313",
+    BACKGROUND_COLOR: "#DCEDC1",
+    BOX_BORDER: "#525252",
+  },
+};

--- a/src/containers/Drawing/index.jsx
+++ b/src/containers/Drawing/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import {
@@ -6,7 +6,7 @@ import {
   drawLineWithHighlighter,
   drawLineWithEraser,
 } from "../../../utils/drawLine";
-import hasClass from "../../../utils/hasClass";
+import isMouseOn from "../../../utils/isMouseOn";
 
 const DrawingContainer = styled.div`
   canvas {
@@ -60,6 +60,8 @@ const Drawing = () => {
     const canvas = canvasRef.current;
     const context = canvas.getContext("2d");
     const scrapWindow = document.getElementById("scrapWindowContentBox");
+    const sidebar = document.getElementById("sidebar");
+    const drawingModeModal = document.getElementById("drawingModeModal");
 
     let drawing = false;
     let highlighterEndPosition;
@@ -68,7 +70,8 @@ const Drawing = () => {
     const onMouseDown = (event) => {
       if (
         selectedSidebarToolRef.current !== "drawingMode" ||
-        hasClass(event.target, "ignoreClick")
+        isMouseOn(sidebar) ||
+        isMouseOn(drawingModeModal)
       )
         return;
 
@@ -170,7 +173,7 @@ const Drawing = () => {
         ref={canvasRef}
         id="drawingCanvas"
         style={{
-          zIndex: selectedSidebarToolRef.current === "drawingMode" ? "1" : "-1",
+          zIndex: selectedSidebarTool === "drawingMode" ? "1" : "-1",
         }}
       />
     </DrawingContainer>

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import hasClass from "../../../utils/hasClass";
 import isMouseOn from "../../../utils/isMouseOn";
 import COLORS from "../../constants/COLORS";
+import THEME from "../../constants/THEME";
 import Drawing from "../Drawing";
 import EditModal from "../EditModeModal";
 
@@ -57,6 +58,31 @@ const ScrapWindowContainer = styled.div`
     box-shadow: 0 0 0 2px #ff676775 !important;
     border-radius: 2px;
   }
+
+  .theme-dark {
+    color: ${THEME.DARK.FONT_COLOR} !important;
+    background-color: ${THEME.DARK.BACKGROUND_COLOR}!important;
+  }
+
+  .theme-blue {
+    color: ${THEME.BLUE.FONT_COLOR} !important;
+    background-color: ${THEME.BLUE.BACKGROUND_COLOR} !important;
+  }
+
+  .theme-brown {
+    color: ${THEME.BROWN.FONT_COLOR} !important;
+    background-color: ${THEME.BROWN.BACKGROUND_COLOR} !important;
+  }
+
+  .theme-skyblue {
+    color: ${THEME.SKY_BLUE.FONT_COLOR} !important;
+    background-color: ${THEME.SKY_BLUE.BACKGROUND_COLOR} !important;
+  }
+
+  .theme-green {
+    color: ${THEME.GREEN.FONT_COLOR} !important;
+    background-color: ${THEME.GREEN.BACKGROUND_COLOR} !important;
+  }
 `;
 
 const Box = styled.div`
@@ -76,6 +102,7 @@ const ScrapWindow = () => {
   const sidebarModeOptionRef = useRef(null);
   const selectedSidebarToolRef = useRef(false);
 
+  const { theme } = useSelector(({ theme }) => theme);
   const { sidebarModeOption } = useSelector(
     ({ sidebarModeOption }) => sidebarModeOption
   );
@@ -228,13 +255,13 @@ const ScrapWindow = () => {
   return (
     <ScrapWindowContainer ref={resizableElementRef} className="resizable">
       <div
-        contentEditable={selectedSidebarToolRef.current === "editMode"}
+        contentEditable={selectedSidebarTool === "editMode"}
         suppressContentEditableWarning={true}
         style={{
-          userSelect: selectedSidebarToolRef.current === "selectMode" && "none",
+          userSelect: selectedSidebarTool === "selectMode" && "none",
         }}
         id="scrapWindowContentBox"
-        className="contentBox"
+        className={`contentBox ${theme}`}
       >
         <Box className="BoxComponent"></Box>
         <EditModal />

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -10,6 +10,7 @@ import SidebarDrawingModeModal from "../SidebarDrawingModeModal";
 import SidebarFoldButton from "../SidebarFoldButton";
 import SidebarSaveModeModal from "../SidebarSaveModeModal";
 import SidebarSelectModeModal from "../SidebarSelectModeModal";
+import SidebarThemeModeModal from "../SidebarThemeModeModal";
 import SidebarTool from "../SidebarTool";
 
 const SidebarContainer = styled.div`
@@ -34,6 +35,7 @@ const Sidebar = () => {
 
   return (
     <SidebarContainer
+      id="sidebar"
       style={{
         transform: isFold ? ["translateX(-100px)"] : ["translateX(0px)"],
       }}
@@ -42,6 +44,7 @@ const Sidebar = () => {
       <SidebarBoxModeModal />
       <SidebarDrawingModeModal />
       <SidebarSaveModeModal />
+      <SidebarThemeModeModal />
       {SIDEBAR_TOOLS.map((value, index) => {
         return <SidebarTool icon={value.ICON} mode={value.MODE} key={index} />;
       })}

--- a/src/containers/SidebarSaveModeModal/index.jsx
+++ b/src/containers/SidebarSaveModeModal/index.jsx
@@ -63,7 +63,6 @@ const SidebarSaveModeModal = () => {
       }}
     >
       <h3>Save Mode</h3>
-
       <ReactToPrint
         trigger={() => (
           <div className="sidebarModeOption" onClick={() => {}}>

--- a/src/containers/SidebarThemeModeModal/index.jsx
+++ b/src/containers/SidebarThemeModeModal/index.jsx
@@ -1,0 +1,240 @@
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import COLORS from "../../constants/COLORS";
+import THEME from "../../constants/THEME";
+import { setTheme } from "../../redux/reducers/theme";
+
+const SidebarThemeModeModalContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 20px 30px;
+  top: 43vh;
+  left: 90px;
+  min-width: 250px;
+  background-color: ${COLORS.SUB_COLOR};
+  border: 2px solid ${COLORS.MAIN_COLOR};
+  border-radius: 5px;
+
+  .scrapWindowWidthBox {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 130px;
+  }
+
+  .sidebarModeOption {
+    margin: 5px 0px;
+    padding: 3px 10px;
+    text-align: center;
+    background-color: ${COLORS.SUB_COLOR};
+    border: 1px solid ${COLORS.MAIN_COLOR};
+    border-radius: 5px;
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+
+    :hover {
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+    }
+
+    :active {
+      opacity: 0.4;
+    }
+  }
+
+  hr {
+    background-color: ${COLORS.MAIN_COLOR};
+    height: 2px;
+    width: 200px;
+  }
+
+  .themeBox {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    width: 200px;
+
+    .theme {
+      margin: 5px;
+      height: 50px;
+      width: 50px;
+      border: 2px solid ${COLORS.MAIN_COLOR};
+      border-radius: 5px;
+      user-select: none;
+      cursor: pointer;
+    }
+
+    .light {
+      background-color: white;
+    }
+
+    .dark {
+      background-color: ${THEME.DARK.BACKGROUND_COLOR};
+    }
+
+    .brown {
+      background-color: ${THEME.BROWN.BACKGROUND_COLOR};
+    }
+
+    .blue {
+      background-color: ${THEME.BLUE.BACKGROUND_COLOR};
+    }
+
+    .skyblue {
+      background-color: ${THEME.SKY_BLUE.BACKGROUND_COLOR};
+    }
+
+    .green {
+      background-color: ${THEME.GREEN.BACKGROUND_COLOR};
+    }
+  }
+
+  .selected {
+    color: ${COLORS.SUB_COLOR};
+    background-color: ${COLORS.MAIN_COLOR};
+  }
+`;
+
+const SidebarThemeModeModal = () => {
+  const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  const [scrapWindowWidth, setScrapWindowWidth] = useState(500);
+
+  const dispatch = useDispatch();
+
+  const { DARK, BROWN, BLUE, SKY_BLUE, GREEN } = THEME;
+
+  return (
+    <SidebarThemeModeModalContainer
+      style={{
+        display:
+          (selectedSidebarTool !== "themeMode" || !isSidebarModalOpen) &&
+          "none",
+      }}
+    >
+      <h3>Theme Mode</h3>
+      <h5>Width</h5>
+      <div className="scrapWindowWidthBox">
+        <div
+          className="sidebarModeOption"
+          onClick={() => {
+            if (scrapWindowWidth > 300) {
+              const boxes = document.getElementsByClassName("BoxComponent");
+
+              for (let i = 0; i < boxes.length; i++) {
+                boxes[i].style.width = `${scrapWindowWidth - 100}px`;
+              }
+
+              setScrapWindowWidth(scrapWindowWidth - 100);
+            }
+          }}
+        >
+          -
+        </div>
+        {scrapWindowWidth}px
+        <div
+          className="sidebarModeOption"
+          onClick={() => {
+            if (scrapWindowWidth < 1000) {
+              const boxes = document.getElementsByClassName("BoxComponent");
+
+              for (let i = 0; i < boxes.length; i++) {
+                boxes[i].style.width = `${scrapWindowWidth + 100}px`;
+              }
+
+              setScrapWindowWidth(scrapWindowWidth + 100);
+            }
+          }}
+        >
+          +
+        </div>
+      </div>
+      <hr />
+      <h5>Theme</h5>
+      <div className="themeBox">
+        <div
+          className="theme light"
+          onClick={() => {
+            const boxes = document.getElementsByClassName("BoxComponent");
+
+            for (let i = 0; i < boxes.length; i++) {
+              boxes[i].style.boxShadow = "0 0 0 2px #ccc";
+            }
+
+            dispatch(setTheme("theme-light"));
+          }}
+        />
+        <div
+          className="theme dark"
+          onClick={() => {
+            const boxes = document.getElementsByClassName("BoxComponent");
+
+            for (let i = 0; i < boxes.length; i++) {
+              boxes[i].style.boxShadow = `0 0 0 2px ${DARK.BOX_BORDER}`;
+            }
+
+            dispatch(setTheme("theme-dark"));
+          }}
+        />
+        <div
+          className="theme brown"
+          onClick={() => {
+            const boxes = document.getElementsByClassName("BoxComponent");
+
+            for (let i = 0; i < boxes.length; i++) {
+              boxes[i].style.boxShadow = `0 0 0 2px ${BROWN.BOX_BORDER}`;
+            }
+
+            dispatch(setTheme("theme-brown"));
+          }}
+        />
+        <div
+          className="theme blue"
+          onClick={() => {
+            const boxes = document.getElementsByClassName("BoxComponent");
+
+            for (let i = 0; i < boxes.length; i++) {
+              boxes[i].style.boxShadow = `0 0 0 2px ${BLUE.BOX_BORDER}`;
+            }
+
+            dispatch(setTheme("theme-blue"));
+          }}
+        />
+        <div
+          className="theme skyblue"
+          onClick={() => {
+            const boxes = document.getElementsByClassName("BoxComponent");
+
+            for (let i = 0; i < boxes.length; i++) {
+              boxes[i].style.boxShadow = `0 0 0 2px ${SKY_BLUE.BOX_BORDER}`;
+            }
+
+            dispatch(setTheme("theme-skyblue"));
+          }}
+        />
+        <div
+          className="theme green"
+          onClick={() => {
+            const boxes = document.getElementsByClassName("BoxComponent");
+
+            for (let i = 0; i < boxes.length; i++) {
+              boxes[i].style.boxShadow = `0 0 0 2px ${GREEN.BOX_BORDER}`;
+            }
+
+            dispatch(setTheme("theme-green"));
+          }}
+        />
+      </div>
+    </SidebarThemeModeModalContainer>
+  );
+};
+
+export default SidebarThemeModeModal;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -3,6 +3,7 @@ import blocks from "./reducers/blocks";
 import lineStyle from "./reducers/lineStyle";
 import selectedSidebarTool from "./reducers/selectedSidebarTool";
 import sidebarModeOption from "./reducers/sidebarModeOption";
+import theme from "./reducers/theme";
 
 import urlAddress from "./reducers/urlAddress";
 
@@ -13,6 +14,7 @@ const store = configureStore({
     selectedSidebarTool: selectedSidebarTool,
     sidebarModeOption: sidebarModeOption,
     lineStyle: lineStyle,
+    theme: theme,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/redux/reducers/theme.js
+++ b/src/redux/reducers/theme.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const theme = createSlice({
+  name: "theme",
+  initialState: {
+    theme: "theme-light",
+  },
+  reducers: {
+    setTheme(state, action) {
+      state.theme = action.payload;
+    },
+  },
+});
+
+export const { setTheme } = theme.actions;
+
+export default theme.reducer;


### PR DESCRIPTION
# Topic
- Theme Mode 구현

# Detail

https://user-images.githubusercontent.com/99075014/202905257-0eed0739-19a7-425a-9e49-fe7e452461a4.mov

- 유저가 Scrap Window안의 컨텐츠 너비를 조정할 수 있다.
- 유저가 Scrap Window안의 컨텐츠의 색상 테마를 조정할 수 있다.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Theme-Mode-28bfcfe7b43241378845bfeee87939df

# Kanban List
- [x]  유저는 Sidebar에서 Theme Mode 아이콘을 클릭할 수 있다.
    1. Theme Mode가 선택되면 Sidebar에 Modal이 나타난다.
    2. Modal에서 Window의 Content 너비를 조절할 수 있다.
    3. Modal에서 Window의 Content 색상테마를 선택할 수 있다.

# ETC
- 해당사항 없음