### PR TITLE
[2022.11.21] Share Mode 정적 페이지 공유 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.19.1",
+  "version": "0.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.19.1",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.19.1",
+  "version": "0.20.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -4,12 +4,15 @@ import { useState } from "react";
 import { useRef } from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
+import { SERVER_ADDRESS } from "../../../utils/env";
 import hasClass from "../../../utils/hasClass";
 import isMouseOn from "../../../utils/isMouseOn";
 import COLORS from "../../constants/COLORS";
 import THEME from "../../constants/THEME";
 import Drawing from "../Drawing";
 import EditModal from "../EditModeModal";
+import io from "socket.io-client";
+import getCookie from "../../../utils/getCookie";
 
 const ScrapWindowContainer = styled.div`
   display: flex;
@@ -101,6 +104,7 @@ const ScrapWindow = () => {
   const rightResizerRef = useRef(null);
   const sidebarModeOptionRef = useRef(null);
   const selectedSidebarToolRef = useRef(false);
+  const socketRef = useRef(null);
 
   const { theme } = useSelector(({ theme }) => theme);
   const { sidebarModeOption } = useSelector(
@@ -180,6 +184,8 @@ const ScrapWindow = () => {
     };
 
     const scrapWindowMousedown = (event) => {
+      socketRef.current.emit("user-send", scrapWindow.outerHTML);
+
       if (event.target === scrapWindow || event.target === drawingCanvas)
         return;
 
@@ -243,6 +249,11 @@ const ScrapWindow = () => {
 
       selectedElement = null;
     };
+
+    socketRef.current = io.connect(`${SERVER_ADDRESS}`);
+    socketRef.current.on("user-send", (data) => {
+      console.log(data);
+    });
 
     resizerRight.addEventListener("mousedown", onMouseDownRightResize);
     scrapWindow.addEventListener("mouseover", scrapWindowContentMouseover);

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -10,6 +10,7 @@ import SidebarDrawingModeModal from "../SidebarDrawingModeModal";
 import SidebarFoldButton from "../SidebarFoldButton";
 import SidebarSaveModeModal from "../SidebarSaveModeModal";
 import SidebarSelectModeModal from "../SidebarSelectModeModal";
+import SidebarShareModeModal from "../SidebarShareModeModal";
 import SidebarThemeModeModal from "../SidebarThemeModeModal";
 import SidebarTool from "../SidebarTool";
 
@@ -45,6 +46,7 @@ const Sidebar = () => {
       <SidebarDrawingModeModal />
       <SidebarSaveModeModal />
       <SidebarThemeModeModal />
+      <SidebarShareModeModal />
       {SIDEBAR_TOOLS.map((value, index) => {
         return <SidebarTool icon={value.ICON} mode={value.MODE} key={index} />;
       })}

--- a/src/containers/SidebarShareModeModal/index.jsx
+++ b/src/containers/SidebarShareModeModal/index.jsx
@@ -1,0 +1,144 @@
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import deleteCookie from "../../../utils/deleteCookie";
+import { SERVER_ADDRESS } from "../../../utils/env";
+import getCookie from "../../../utils/getCookie";
+import COLORS from "../../constants/COLORS";
+import { setUrlAddress } from "../../redux/reducers/urlAddress";
+
+const SidebarShareModeModalContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 20px 30px;
+  top: 50vh;
+  left: 90px;
+  min-width: 250px;
+  background-color: ${COLORS.SUB_COLOR};
+  border: 2px solid ${COLORS.MAIN_COLOR};
+  border-radius: 5px;
+
+  .sidebarModeOption {
+    margin: 5px 0px;
+    padding: 3px 10px;
+    text-align: center;
+    background-color: ${COLORS.SUB_COLOR};
+    border: 1px solid ${COLORS.MAIN_COLOR};
+    border-radius: 5px;
+    transition: all 0.2s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+
+    :hover {
+      color: ${COLORS.SUB_COLOR};
+      background-color: ${COLORS.MAIN_COLOR};
+    }
+
+    :active {
+      opacity: 0.4;
+    }
+  }
+
+  .selected {
+    color: ${COLORS.SUB_COLOR};
+    background-color: ${COLORS.MAIN_COLOR};
+  }
+
+  hr {
+    background-color: ${COLORS.MAIN_COLOR};
+    height: 2px;
+    width: 200px;
+  }
+`;
+
+const SidebarShareModeModal = () => {
+  const { urlAddress } = useSelector(({ urlAddress }) => urlAddress);
+  const { selectedSidebarTool, isSidebarModalOpen } = useSelector(
+    ({ selectedSidebarTool }) => selectedSidebarTool
+  );
+
+  const [keyInput, setKeyInput] = useState("");
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    (async () => {
+      if (getCookie("shareModeKey")) {
+        const scrapWindow = document.getElementById("scrapWindowContentBox");
+        const scrapContent = await axios.get(
+          `${SERVER_ADDRESS}${getCookie("shareModeKey")}/shareMode`
+        );
+
+        scrapWindow.innerHTML = scrapContent.data.scrapContent.content;
+
+        dispatch(setUrlAddress(scrapContent.data.scrapContent.urlAddress));
+        deleteCookie("shareModeKey");
+      }
+    })();
+  }, []);
+
+  return (
+    <SidebarShareModeModalContainer
+      style={{
+        display:
+          (selectedSidebarTool !== "shareMode" || !isSidebarModalOpen) &&
+          "none",
+      }}
+    >
+      <h3>Share Mode</h3>
+      <div
+        className="sidebarModeOption"
+        onClick={async () => {
+          const scrapWindow = document.getElementById("scrapWindowContentBox");
+          const copyKey = document.getElementById("shareKeyInput");
+
+          const newScrapContent = await axios.post(
+            `${SERVER_ADDRESS}shareMode`,
+            {
+              content: scrapWindow.innerHTML,
+              urlAddress,
+            }
+          );
+
+          copyKey.value = newScrapContent.data.id.toString();
+
+          copyKey.select();
+          copyKey.setSelectionRange(0, 99999);
+          document.execCommand("Copy");
+          alert("Key가 성공적으로 생성되었습니다.");
+          copyUrlFnc();
+        }}
+      >
+        Create Link
+      </div>
+      <input id="shareKeyInput" />
+      <hr />
+      <div
+        className="sidebarModeOption"
+        onClick={async () => {
+          const scrapWindow = document.getElementById("scrapWindowContentBox");
+          const scrapContent = await axios.get(
+            `${SERVER_ADDRESS}${keyInput}/shareMode`
+          );
+
+          scrapWindow.innerHTML = scrapContent.data.scrapContent.content;
+
+          dispatch(setUrlAddress(scrapContent.data.scrapContent.urlAddress));
+        }}
+      >
+        Connect
+      </div>
+      <input
+        onChange={(event) => {
+          setKeyInput(event.target.value);
+        }}
+      />
+    </SidebarShareModeModalContainer>
+  );
+};
+
+export default SidebarShareModeModal;

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -211,10 +211,20 @@ const WebWindow = () => {
     window.addEventListener("mouseup", windowMouseup);
 
     (async () => {
-      const url =
-        getCookie("urlAddress") ||
-        urlAddress ||
-        "https://illuminating-extol-innovation.w3spaces.com/";
+      let url;
+
+      if (getCookie("shareModeKey")) {
+        const scrapContent = await axios.get(
+          `${SERVER_ADDRESS}${getCookie("shareModeKey")}/shareMode`
+        );
+
+        url = scrapContent.data.scrapContent.urlAddress;
+      } else {
+        url =
+          getCookie("urlAddress") ||
+          urlAddress ||
+          "https://illuminating-extol-innovation.w3spaces.com/";
+      }
 
       const sourceDomain = url.slice(`https://`.length).split("/").shift();
       const { data } = await axios.get(url);
@@ -222,9 +232,7 @@ const WebWindow = () => {
         originalHtml: data,
         sourceDomain,
       });
-      console.log("SERVER_ADDRESS", SERVER_ADDRESS);
-
-      dispatch(setUrlAddress(htmlString.data.htmlString));
+      dispatch(setUrlAddress(url));
 
       if (getCookie("urlAddress")) {
         deleteCookie("urlAddress");
@@ -232,7 +240,7 @@ const WebWindow = () => {
 
       setIframeDom(htmlString.data.htmlString);
     })();
-  }, []);
+  }, [urlAddress]);
 
   return (
     <WebWindowContainer id="webWindow" ref={webWindowRef}>

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import setCookie from "../../../utils/setCookie";
 
@@ -61,15 +61,14 @@ const PopupContainer = styled.div`
 `;
 
 const Popup = () => {
-  useEffect(() => {
-    chrome.tabs.query(
-      { active: true, lastFocusedWindow: true },
-      function (tabs) {
-        const url = tabs[0].url;
+  const [shareModeKey, setShareModeKey] = useState("");
 
-        setCookie("urlAddress", url, 1);
-      }
-    );
+  useEffect(() => {
+    chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+      const url = tabs[0].url;
+
+      setCookie("urlAddress", url, 1);
+    });
   }, []);
 
   return (
@@ -88,8 +87,19 @@ const Popup = () => {
       <h3>Scrap this page</h3>
       <hr />
       <h3>Enter shared page</h3>
-      <input />
-      <button>Connect</button>
+      <input
+        onChange={(event) => {
+          setShareModeKey(event.target.value);
+        }}
+      />
+      <button
+        onClick={() => {
+          setCookie("shareModeKey", shareModeKey, 1);
+          window.open("main.html");
+        }}
+      >
+        Connect
+      </button>
     </PopupContainer>
   );
 };

--- a/utils/env.js
+++ b/utils/env.js
@@ -1,5 +1,5 @@
 module.exports = {
   NODE_ENV: process.env.NODE_ENV || "development",
-  PORT: process.env.PORT || 3000,
+  PORT: process.env.PORT || 3001,
   SERVER_ADDRESS: process.env.SERVER_ADDRESS,
 };

--- a/utils/webserver.js
+++ b/utils/webserver.js
@@ -1,12 +1,12 @@
-process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
-process.env.ASSET_PATH = '/';
+process.env.BABEL_ENV = "development";
+process.env.NODE_ENV = "development";
+process.env.ASSET_PATH = "/";
 
-const WebpackDevServer = require('webpack-dev-server');
-const webpack = require('webpack');
-const config = require('../webpack.config');
-const env = require('./env');
-const path = require('path');
+const WebpackDevServer = require("webpack-dev-server");
+const webpack = require("webpack");
+const config = require("../webpack.config");
+const env = require("./env");
+const path = require("path");
 
 const options = config.chromeExtensionBoilerplate || {};
 const excludeEntriesToHotReload = options.notHotReload || [];
@@ -14,7 +14,7 @@ const excludeEntriesToHotReload = options.notHotReload || [];
 for (const entryName in config.entry) {
   if (excludeEntriesToHotReload.indexOf(entryName) === -1) {
     config.entry[entryName] = [
-      'webpack/hot/dev-server',
+      "webpack/hot/dev-server",
       `webpack-dev-server/client?hot=true&hostname=localhost&port=${env.PORT}`,
     ].concat(config.entry[entryName]);
   }
@@ -33,24 +33,24 @@ const server = new WebpackDevServer(
     https: false,
     hot: false,
     client: false,
-    host: 'localhost',
+    host: "localhost",
     port: env.PORT,
     static: {
-      directory: path.join(__dirname, '../build'),
+      directory: path.join(__dirname, "../build"),
     },
     devMiddleware: {
       publicPath: `http://localhost:${env.PORT}/`,
       writeToDisk: true,
     },
     headers: {
-      'Access-Control-Allow-Origin': '*',
+      "Access-Control-Allow-Origin": "*",
     },
-    allowedHosts: 'all',
+    allowedHosts: "all",
   },
   compiler
 );
 
-if (process.env.NODE_ENV === 'development' && module.hot) {
+if (process.env.NODE_ENV === "development" && module.hot) {
   module.hot.accept();
 }
 


### PR DESCRIPTION
# Topic
- Share Mode 정적 페이지 공유 구현

# Detail

https://user-images.githubusercontent.com/99075014/203054232-233abebb-9f8d-4d32-ab8a-8179ea31643f.mov

- 유저가 제작한 Scrap Window를 공유할 수 있는 Key를 생성할 수 있다.
- 해당 Key를 Popup페이지 또는 Share Mode 모달에 입력 후 Connect를 누르면 해당 페이지를 공유받을 수 있다.
- Socket을 통한 실시간 공유 기능 보완 필요.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Share-Mode-78372af0e5a943b5ad974ff3bee08fe0

# Kanban List
- [x]  유저는 Sidebar에서 Share Mode 아이콘을 클릭할 수 있다.
    - [x]  Share Mode를 누르면 해당 Scrap Window의가 Key가 클립보드로 복사된다.
    - [x]  다른 유저들이 해당 Key를 통해 접속하면 공유한 Scrap Window로 볼 수 있다.
    - [ ]  공유가 Socket을 통해 실시간으로 이루어져야한다.

# ETC
- 해당사항 없음