### PR TITLE
[2022.11.22] Share Mode Socket을 통한 실시간 공유 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Web Collage",
-  "version": "0.20.1",
+  "version": "0.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Web Collage",
-      "version": "0.20.1",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-collage",
-  "version": "0.20.1",
+  "version": "0.21.1",
   "description": "A scrap chrome extension that can take the HTML DOM element of a web page and reconfigure it in a user-desired format.",
   "license": "MIT",
   "repository": {

--- a/src/containers/Drawing/index.jsx
+++ b/src/containers/Drawing/index.jsx
@@ -67,7 +67,7 @@ const Drawing = () => {
     let highlighterEndPosition;
     let startPosition;
 
-    const onMouseDown = (event) => {
+    const onClick = (event) => {
       if (
         selectedSidebarToolRef.current !== "drawingMode" ||
         isMouseOn(sidebar) ||
@@ -153,7 +153,7 @@ const Drawing = () => {
       }
     };
 
-    window.addEventListener("mousedown", onMouseDown, false);
+    window.addEventListener("mousedown", onClick, false);
     window.addEventListener("mouseup", onMouseUp, false);
     window.addEventListener("mouseout", onMouseUp, false);
     window.addEventListener("mousemove", onMouseMove, false);

--- a/src/containers/ScrapWindow/index.jsx
+++ b/src/containers/ScrapWindow/index.jsx
@@ -152,7 +152,7 @@ const ScrapWindow = () => {
       document.removeEventListener("mousemove", onMouseMoveRightResize);
     };
 
-    const onMouseDownRightResize = (event) => {
+    const onClickRightResize = (event) => {
       windowX = event.clientX;
       resizableElement.style.left = styles.left;
       resizableElement.style.right = null;
@@ -184,8 +184,6 @@ const ScrapWindow = () => {
     };
 
     const scrapWindowMousedown = (event) => {
-      socketRef.current.emit("user-send", scrapWindow.outerHTML);
-
       if (event.target === scrapWindow || event.target === drawingCanvas)
         return;
 
@@ -248,14 +246,24 @@ const ScrapWindow = () => {
       }
 
       selectedElement = null;
+
+      socketRef.current.emit("user-send", scrapWindow.innerHTML);
     };
+
+    window.addEventListener("mouseup", () => {
+      socketRef.current.emit("user-send", scrapWindow.innerHTML);
+    });
+
+    window.addEventListener("keyup", () => {
+      socketRef.current.emit("user-send", scrapWindow.innerHTML);
+    });
 
     socketRef.current = io.connect(`${SERVER_ADDRESS}`);
     socketRef.current.on("user-send", (data) => {
-      console.log(data);
+      scrapWindow.innerHTML = data;
     });
 
-    resizerRight.addEventListener("mousedown", onMouseDownRightResize);
+    resizerRight.addEventListener("mousedown", onClickRightResize);
     scrapWindow.addEventListener("mouseover", scrapWindowContentMouseover);
     scrapWindow.addEventListener("mouseout", scrapWindowContentMouseout);
     scrapWindow.addEventListener("mousedown", scrapWindowMousedown);

--- a/src/containers/WebWindow/index.jsx
+++ b/src/containers/WebWindow/index.jsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import React, { useRef } from "react";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { io } from "socket.io-client";
 import styled from "styled-components";
 import deleteCookie from "../../../utils/deleteCookie";
 import { SERVER_ADDRESS } from "../../../utils/env";
@@ -103,6 +104,7 @@ const WebWindow = () => {
   const blockRef = useRef(null);
   const webWindowRef = useRef(null);
   const isScrapModeRef = useRef(false);
+  const socketRef = useRef(null);
 
   const { urlAddress } = useSelector(({ urlAddress }) => urlAddress);
 
@@ -185,6 +187,9 @@ const WebWindow = () => {
           );
 
           block.style.display = "none";
+
+          socketRef.current.emit("user-send", scrapWindow.innerHTML);
+
           return;
         }
       }
@@ -202,7 +207,11 @@ const WebWindow = () => {
       }
 
       block.style.display = "none";
+
+      socketRef.current.emit("user-send", scrapWindow.innerHTML);
     };
+
+    socketRef.current = io.connect(`${SERVER_ADDRESS}`);
 
     webWindowContent.addEventListener("mouseover", webWindowContentMouseover);
     webWindowContent.addEventListener("mouseout", webWindowContentMouseout);


### PR DESCRIPTION
# Topic
- Share Mode Socket을 통한 실시간 공유 구현

# Detail

https://user-images.githubusercontent.com/99075014/203103975-99803c35-f339-4a16-9d09-21c63a38213c.mov

- 유저가 Share Mode로 페이지 공유시 서로의 Window가 Socket을 통해 실시간으로 공유된다.

# Kanban Link
https://expensive-scorpion-fab.notion.site/Feature-Share-Mode-78372af0e5a943b5ad974ff3bee08fe0

# Kanban List
- [x]  유저는 Sidebar에서 Share Mode 아이콘을 클릭할 수 있다.
    - [x]  Share Mode를 누르면 해당 Scrap Window의가 Key가 클립보드로 복사된다.
    - [x]  다른 유저들이 해당 Key를 통해 접속하면 공유한 Scrap Window로 볼 수 있다.
    - [x]  공유가 Socket을 통해 실시간으로 이루어져야한다.

# ETC
- 해당사항 없음